### PR TITLE
feat: implement PartnerManager authorization system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "packages/foundry/lib/solidity-bytes-utils"]
 	path = packages/foundry/lib/solidity-bytes-utils
 	url = https://github.com/gnsps/solidity-bytes-utils
+[submodule "protocols/evm/lib/openzeppelin-contracts-upgradeable"]
+	path = protocols/evm/lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/protocols/evm/contracts/PartnerManager.sol
+++ b/protocols/evm/contracts/PartnerManager.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/**
+ * @title PartnerManager
+ * @dev Manages authorized partners for the Roboshare protocol
+ * Partners can register vehicles and participate in the ecosystem
+ */
+contract PartnerManager is 
+    Initializable,
+    AccessControlUpgradeable,
+    UUPSUpgradeable
+{
+    bytes32 public constant PARTNER_ADMIN_ROLE = keccak256("PARTNER_ADMIN_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    // Partner state
+    mapping(address => bool) private _authorizedPartners;
+    mapping(address => string) private _partnerNames;
+    mapping(address => uint256) private _partnerRegistrationTime;
+    address[] private _allPartners;
+
+    // Events
+    event PartnerAuthorized(address indexed partner, string name);
+    event PartnerRevoked(address indexed partner);
+    event PartnerNameUpdated(address indexed partner, string newName);
+
+    // Errors
+    error PartnerManager__AlreadyAuthorized();
+    error PartnerManager__NotAuthorized();
+    error PartnerManager__EmptyName();
+    error PartnerManager__ZeroAddress();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address defaultAdmin) public initializer {
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
+        _grantRole(PARTNER_ADMIN_ROLE, defaultAdmin);
+        _grantRole(UPGRADER_ROLE, defaultAdmin);
+    }
+
+    /**
+     * @dev Authorize a new partner
+     * @param partner Address of the partner to authorize
+     * @param name Name of the partner organization
+     */
+    function authorizePartner(address partner, string calldata name) 
+        external 
+        onlyRole(PARTNER_ADMIN_ROLE) 
+    {
+        if (partner == address(0)) revert PartnerManager__ZeroAddress();
+        if (bytes(name).length == 0) revert PartnerManager__EmptyName();
+        if (_authorizedPartners[partner]) revert PartnerManager__AlreadyAuthorized();
+
+        _authorizedPartners[partner] = true;
+        _partnerNames[partner] = name;
+        _partnerRegistrationTime[partner] = block.timestamp;
+        _allPartners.push(partner);
+
+        emit PartnerAuthorized(partner, name);
+    }
+
+    /**
+     * @dev Revoke partner authorization
+     * @param partner Address of the partner to revoke
+     */
+    function revokePartner(address partner) 
+        external 
+        onlyRole(PARTNER_ADMIN_ROLE) 
+    {
+        if (!_authorizedPartners[partner]) revert PartnerManager__NotAuthorized();
+
+        _authorizedPartners[partner] = false;
+        delete _partnerNames[partner];
+        delete _partnerRegistrationTime[partner];
+
+        // Remove from array
+        for (uint256 i = 0; i < _allPartners.length; i++) {
+            if (_allPartners[i] == partner) {
+                _allPartners[i] = _allPartners[_allPartners.length - 1];
+                _allPartners.pop();
+                break;
+            }
+        }
+
+        emit PartnerRevoked(partner);
+    }
+
+    /**
+     * @dev Update partner name
+     * @param partner Address of the partner
+     * @param newName New name for the partner
+     */
+    function updatePartnerName(address partner, string calldata newName) 
+        external 
+        onlyRole(PARTNER_ADMIN_ROLE) 
+    {
+        if (!_authorizedPartners[partner]) revert PartnerManager__NotAuthorized();
+        if (bytes(newName).length == 0) revert PartnerManager__EmptyName();
+
+        _partnerNames[partner] = newName;
+        emit PartnerNameUpdated(partner, newName);
+    }
+
+    /**
+     * @dev Check if an address is an authorized partner
+     * @param partner Address to check
+     * @return True if partner is authorized
+     */
+    function isAuthorizedPartner(address partner) external view returns (bool) {
+        return _authorizedPartners[partner];
+    }
+
+    /**
+     * @dev Get partner name
+     * @param partner Address of the partner
+     * @return Name of the partner
+     */
+    function getPartnerName(address partner) external view returns (string memory) {
+        return _partnerNames[partner];
+    }
+
+    /**
+     * @dev Get partner registration time
+     * @param partner Address of the partner
+     * @return Timestamp when partner was registered
+     */
+    function getPartnerRegistrationTime(address partner) external view returns (uint256) {
+        return _partnerRegistrationTime[partner];
+    }
+
+    /**
+     * @dev Get all authorized partners
+     * @return Array of all partner addresses
+     */
+    function getAllPartners() external view returns (address[] memory) {
+        return _allPartners;
+    }
+
+    /**
+     * @dev Get number of authorized partners
+     * @return Count of authorized partners
+     */
+    function getPartnerCount() external view returns (uint256) {
+        return _allPartners.length;
+    }
+
+    /**
+     * @dev Get partner info
+     * @param partner Address of the partner
+     * @return name Partner name
+     * @return registrationTime When partner was registered
+     * @return isAuthorized Current authorization status
+     */
+    function getPartnerInfo(address partner) 
+        external 
+        view 
+        returns (
+            string memory name,
+            uint256 registrationTime,
+            bool isAuthorized
+        ) 
+    {
+        return (
+            _partnerNames[partner],
+            _partnerRegistrationTime[partner],
+            _authorizedPartners[partner]
+        );
+    }
+
+    /**
+     * @dev Modifier to check if caller is authorized partner
+     */
+    modifier onlyAuthorizedPartner() {
+        if (!_authorizedPartners[msg.sender]) revert PartnerManager__NotAuthorized();
+        _;
+    }
+
+    /**
+     * @dev Required override for UUPS upgrades
+     */
+    function _authorizeUpgrade(address newImplementation)
+        internal
+        override
+        onlyRole(UPGRADER_ROLE)
+    {}
+}

--- a/protocols/evm/script/DeployPartnerManager.s.sol
+++ b/protocols/evm/script/DeployPartnerManager.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import "../contracts/PartnerManager.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DeployPartnerManager is Script {
+    function run() external returns (address) {
+        address deployer = msg.sender;
+        
+        console.log("Deploying PartnerManager with deployer:", deployer);
+        console.log("Deployer balance:", deployer.balance);
+        
+        vm.startBroadcast();
+        
+        // Deploy implementation contract
+        PartnerManager partnerImplementation = new PartnerManager();
+        console.log("PartnerManager implementation deployed at:", address(partnerImplementation));
+        
+        // Prepare initialization data
+        bytes memory initData = abi.encodeWithSignature("initialize(address)", deployer);
+        
+        // Deploy proxy contract
+        ERC1967Proxy proxy = new ERC1967Proxy(address(partnerImplementation), initData);
+        console.log("PartnerManager proxy deployed at:", address(proxy));
+        
+        // Wrap proxy in interface
+        PartnerManager partnerManager = PartnerManager(address(proxy));
+        
+        // Verify initialization
+        console.log("Admin has DEFAULT_ADMIN_ROLE:", partnerManager.hasRole(partnerManager.DEFAULT_ADMIN_ROLE(), deployer));
+        console.log("Admin has PARTNER_ADMIN_ROLE:", partnerManager.hasRole(keccak256("PARTNER_ADMIN_ROLE"), deployer));
+        console.log("Admin has UPGRADER_ROLE:", partnerManager.hasRole(keccak256("UPGRADER_ROLE"), deployer));
+        console.log("Initial partner count:", partnerManager.getPartnerCount());
+        
+        vm.stopBroadcast();
+        
+        // Log deployment summary
+        console.log("=== Deployment Summary ===");
+        console.log("Implementation:", address(partnerImplementation));
+        console.log("Proxy (main contract):", address(proxy));
+        console.log("Deployer/Admin:", deployer);
+        console.log("==========================");
+        
+        return address(proxy);
+    }
+}

--- a/protocols/evm/test/PartnerManager.t.sol
+++ b/protocols/evm/test/PartnerManager.t.sol
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "../contracts/PartnerManager.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract PartnerManagerTest is Test {
+    PartnerManager public partnerManager;
+    PartnerManager public partnerImplementation;
+    
+    address public admin = makeAddr("admin");
+    address public partnerAdmin = makeAddr("partnerAdmin");
+    address public partner1 = makeAddr("partner1");
+    address public partner2 = makeAddr("partner2");
+    address public partner3 = makeAddr("partner3");
+    address public unauthorized = makeAddr("unauthorized");
+
+    bytes32 public constant PARTNER_ADMIN_ROLE = keccak256("PARTNER_ADMIN_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    string constant PARTNER1_NAME = "Tesla Motors";
+    string constant PARTNER2_NAME = "Ford Motors";
+    string constant PARTNER3_NAME = "BMW Group";
+
+    event PartnerAuthorized(address indexed partner, string name);
+    event PartnerRevoked(address indexed partner);
+    event PartnerNameUpdated(address indexed partner, string newName);
+
+    function setUp() public {
+        // Deploy implementation
+        partnerImplementation = new PartnerManager();
+        
+        // Deploy proxy
+        bytes memory initData = abi.encodeWithSignature("initialize(address)", admin);
+        ERC1967Proxy proxy = new ERC1967Proxy(address(partnerImplementation), initData);
+        partnerManager = PartnerManager(address(proxy));
+        
+        // Grant roles
+        vm.startPrank(admin);
+        partnerManager.grantRole(PARTNER_ADMIN_ROLE, partnerAdmin);
+        vm.stopPrank();
+    }
+
+    function testInitialization() public {
+        // Check roles
+        assertTrue(partnerManager.hasRole(partnerManager.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(partnerManager.hasRole(PARTNER_ADMIN_ROLE, admin));
+        assertTrue(partnerManager.hasRole(UPGRADER_ROLE, admin));
+        assertTrue(partnerManager.hasRole(PARTNER_ADMIN_ROLE, partnerAdmin));
+        
+        // Check initial state
+        assertEq(partnerManager.getPartnerCount(), 0);
+        assertFalse(partnerManager.isAuthorizedPartner(partner1));
+    }
+
+    function testAuthorizePartner() public {
+        vm.expectEmit(true, true, false, true);
+        emit PartnerAuthorized(partner1, PARTNER1_NAME);
+        
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+        assertEq(partnerManager.getPartnerName(partner1), PARTNER1_NAME);
+        assertEq(partnerManager.getPartnerCount(), 1);
+        assertGt(partnerManager.getPartnerRegistrationTime(partner1), 0);
+        
+        address[] memory partners = partnerManager.getAllPartners();
+        assertEq(partners.length, 1);
+        assertEq(partners[0], partner1);
+    }
+
+    function testAuthorizeMultiplePartners() public {
+        vm.startPrank(partnerAdmin);
+        
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        partnerManager.authorizePartner(partner2, PARTNER2_NAME);
+        partnerManager.authorizePartner(partner3, PARTNER3_NAME);
+        
+        vm.stopPrank();
+        
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+        assertTrue(partnerManager.isAuthorizedPartner(partner2));
+        assertTrue(partnerManager.isAuthorizedPartner(partner3));
+        
+        assertEq(partnerManager.getPartnerCount(), 3);
+        
+        address[] memory partners = partnerManager.getAllPartners();
+        assertEq(partners.length, 3);
+    }
+
+    function testRevokePartner() public {
+        // First authorize
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+        assertEq(partnerManager.getPartnerCount(), 1);
+        
+        // Then revoke
+        vm.expectEmit(true, true, false, true);
+        emit PartnerRevoked(partner1);
+        
+        vm.prank(partnerAdmin);
+        partnerManager.revokePartner(partner1);
+        
+        assertFalse(partnerManager.isAuthorizedPartner(partner1));
+        assertEq(partnerManager.getPartnerName(partner1), "");
+        assertEq(partnerManager.getPartnerRegistrationTime(partner1), 0);
+        assertEq(partnerManager.getPartnerCount(), 0);
+        
+        address[] memory partners = partnerManager.getAllPartners();
+        assertEq(partners.length, 0);
+    }
+
+    function testRevokePartnerFromMiddle() public {
+        // Authorize three partners
+        vm.startPrank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        partnerManager.authorizePartner(partner2, PARTNER2_NAME);
+        partnerManager.authorizePartner(partner3, PARTNER3_NAME);
+        vm.stopPrank();
+        
+        assertEq(partnerManager.getPartnerCount(), 3);
+        
+        // Revoke middle partner
+        vm.prank(partnerAdmin);
+        partnerManager.revokePartner(partner2);
+        
+        assertEq(partnerManager.getPartnerCount(), 2);
+        assertFalse(partnerManager.isAuthorizedPartner(partner2));
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+        assertTrue(partnerManager.isAuthorizedPartner(partner3));
+        
+        address[] memory partners = partnerManager.getAllPartners();
+        assertEq(partners.length, 2);
+        // Array should contain partner1 and partner3 (order may vary due to swap-and-pop)
+        assertTrue((partners[0] == partner1 && partners[1] == partner3) || 
+                  (partners[0] == partner3 && partners[1] == partner1));
+    }
+
+    function testUpdatePartnerName() public {
+        // First authorize
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        string memory newName = "Tesla Inc.";
+        
+        vm.expectEmit(true, true, false, true);
+        emit PartnerNameUpdated(partner1, newName);
+        
+        vm.prank(partnerAdmin);
+        partnerManager.updatePartnerName(partner1, newName);
+        
+        assertEq(partnerManager.getPartnerName(partner1), newName);
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+    }
+
+    function testGetPartnerInfo() public {
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        (string memory name, uint256 registrationTime, bool isAuthorized) = 
+            partnerManager.getPartnerInfo(partner1);
+        
+        assertEq(name, PARTNER1_NAME);
+        assertGt(registrationTime, 0);
+        assertTrue(isAuthorized);
+    }
+
+    // Access Control Tests
+    
+    function testUnauthorizedAuthorizePartnerFails() public {
+        vm.expectRevert();
+        vm.prank(unauthorized);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+    }
+
+    function testUnauthorizedRevokePartnerFails() public {
+        // First authorize
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        vm.expectRevert();
+        vm.prank(unauthorized);
+        partnerManager.revokePartner(partner1);
+    }
+
+    function testUnauthorizedUpdatePartnerNameFails() public {
+        // First authorize
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        vm.expectRevert();
+        vm.prank(unauthorized);
+        partnerManager.updatePartnerName(partner1, "New Name");
+    }
+
+    // Error Cases
+    
+    function testAuthorizeZeroAddressFails() public {
+        vm.expectRevert(PartnerManager.PartnerManager__ZeroAddress.selector);
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(address(0), PARTNER1_NAME);
+    }
+
+    function testAuthorizeEmptyNameFails() public {
+        vm.expectRevert(PartnerManager.PartnerManager__EmptyName.selector);
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, "");
+    }
+
+    function testAuthorizeAlreadyAuthorizedFails() public {
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        vm.expectRevert(PartnerManager.PartnerManager__AlreadyAuthorized.selector);
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+    }
+
+    function testRevokeNotAuthorizedFails() public {
+        vm.expectRevert(PartnerManager.PartnerManager__NotAuthorized.selector);
+        vm.prank(partnerAdmin);
+        partnerManager.revokePartner(partner1);
+    }
+
+    function testUpdateNameNotAuthorizedFails() public {
+        vm.expectRevert(PartnerManager.PartnerManager__NotAuthorized.selector);
+        vm.prank(partnerAdmin);
+        partnerManager.updatePartnerName(partner1, "New Name");
+    }
+
+    function testUpdateEmptyNameFails() public {
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        vm.expectRevert(PartnerManager.PartnerManager__EmptyName.selector);
+        vm.prank(partnerAdmin);
+        partnerManager.updatePartnerName(partner1, "");
+    }
+
+    // Role Management Tests
+    
+    function testRoleManagement() public {
+        address newPartnerAdmin = makeAddr("newPartnerAdmin");
+        
+        // Admin can grant roles
+        vm.prank(admin);
+        partnerManager.grantRole(PARTNER_ADMIN_ROLE, newPartnerAdmin);
+        assertTrue(partnerManager.hasRole(PARTNER_ADMIN_ROLE, newPartnerAdmin));
+        
+        // New partner admin can authorize partners
+        vm.prank(newPartnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+        
+        // Admin can revoke roles
+        vm.prank(admin);
+        partnerManager.revokeRole(PARTNER_ADMIN_ROLE, newPartnerAdmin);
+        assertFalse(partnerManager.hasRole(PARTNER_ADMIN_ROLE, newPartnerAdmin));
+    }
+
+    // Fuzz Tests
+    
+    function testFuzzAuthorizePartner(address partner, string calldata name) public {
+        vm.assume(partner != address(0));
+        vm.assume(bytes(name).length > 0 && bytes(name).length < 100);
+        
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner, name);
+        
+        assertTrue(partnerManager.isAuthorizedPartner(partner));
+        assertEq(partnerManager.getPartnerName(partner), name);
+    }
+
+    function testFuzzMultiplePartners(uint8 numPartners) public {
+        vm.assume(numPartners > 0 && numPartners <= 50);
+        
+        vm.startPrank(partnerAdmin);
+        
+        for (uint8 i = 0; i < numPartners; i++) {
+            address partner = makeAddr(string(abi.encodePacked("partner", i)));
+            string memory name = string(abi.encodePacked("Partner ", vm.toString(i)));
+            partnerManager.authorizePartner(partner, name);
+        }
+        
+        vm.stopPrank();
+        
+        assertEq(partnerManager.getPartnerCount(), numPartners);
+    }
+
+    // Integration Tests
+    
+    function testPartnerLifecycle() public {
+        // Authorize
+        vm.prank(partnerAdmin);
+        partnerManager.authorizePartner(partner1, PARTNER1_NAME);
+        
+        assertTrue(partnerManager.isAuthorizedPartner(partner1));
+        uint256 originalTime = partnerManager.getPartnerRegistrationTime(partner1);
+        
+        // Update name
+        vm.prank(partnerAdmin);
+        partnerManager.updatePartnerName(partner1, "Tesla Inc.");
+        
+        assertEq(partnerManager.getPartnerName(partner1), "Tesla Inc.");
+        assertEq(partnerManager.getPartnerRegistrationTime(partner1), originalTime);
+        
+        // Revoke
+        vm.prank(partnerAdmin);
+        partnerManager.revokePartner(partner1);
+        
+        assertFalse(partnerManager.isAuthorizedPartner(partner1));
+        assertEq(partnerManager.getPartnerName(partner1), "");
+        assertEq(partnerManager.getPartnerRegistrationTime(partner1), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive partner authorization system for Roboshare protocol
- Add role-based access control with PARTNER_ADMIN_ROLE and UPGRADER_ROLE
- Include partner lifecycle management (authorize, revoke, update)
- Provide comprehensive test suite with edge cases and fuzz testing

## Key Features
- Partner authorization and revocation with event emissions
- Partner metadata management (name, registration time)
- Array-based partner enumeration with efficient removal
- Access control modifiers for protocol integration
- UUPS upgradeable architecture

## Test Coverage
- Partner lifecycle operations
- Role-based access control
- Error handling and validation
- Fuzz testing for robustness
- Integration scenarios

## Dependencies
- OpenZeppelin contracts for AccessControl and UUPS
- Foundry for testing and deployment