### PR TITLE
Fix CI workflow script names

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,10 +38,10 @@ jobs:
       - name: Run foundry node, deploy contracts (& generate contracts typescript output)
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-        run: yarn chain & yarn deploy
+        run: yarn chain & sleep 5 && yarn deploy
 
       - name: Run nextjs lint
-        run: yarn next:lint --max-warnings=0
+        run: yarn web:lint --max-warnings=0
 
       - name: Check typings on nextjs
-        run: yarn next:check-types
+        run: yarn web:check-types


### PR DESCRIPTION
## Summary
- Fix yarn script names to match package.json (web:lint, web:check-types)  
- Add sleep to allow anvil to start before deployment

## Test plan
- [ ] CI should now pass with correct script names
- [ ] Anvil gets time to start before deployment runs