### PR TITLE
Fix frontend interaction with UUPS proxy contracts

### DIFF
--- a/protocols/evm/script/Deploy.s.sol
+++ b/protocols/evm/script/Deploy.s.sol
@@ -14,28 +14,27 @@ import { DeployTreasury } from "./DeployTreasury.s.sol";
  * Example: yarn deploy # runs this script(without`--file` flag)
  */
 contract DeployScript is ScaffoldETHDeploy {
-    function run() external {
+    function run() external ScaffoldEthDeployerRunner {
         // Deploy contracts in dependency order
-        
+
         // 1. Deploy base token contract (no dependencies)
         DeployRoboshareTokens deployTokens = new DeployRoboshareTokens();
-        address roboshareTokensProxy = deployTokens.run();
+        address roboshareTokensProxy = deployTokens.run(deployer);
 
-        // 2. Deploy partner manager (no dependencies) 
+        // 2. Deploy partner manager (no dependencies)
         DeployPartnerManager deployPartnerManager = new DeployPartnerManager();
-        address partnerManagerProxy = deployPartnerManager.run();
+        address partnerManagerProxy = deployPartnerManager.run(deployer);
 
         // 3. Deploy vehicle registry (depends on tokens + partner manager)
         DeployVehicleRegistry deployVehicleRegistry = new DeployVehicleRegistry();
-        address vehicleRegistryProxy = deployVehicleRegistry.run(roboshareTokensProxy, partnerManagerProxy);
+        address vehicleRegistryProxy = deployVehicleRegistry.run(roboshareTokensProxy, partnerManagerProxy, deployer);
 
         // 4. Deploy treasury (depends on vehicle registry + partner manager)
         // For local testing, we'll use a mock USDC address (zero address will be caught by validation)
         // In production, this should be the actual USDC contract address
         address usdcAddress = address(0x1234567890123456789012345678901234567890); // Mock USDC for local testing
-        address adminAddress = msg.sender; // Use deployer as admin for local testing
-        
+
         DeployTreasury deployTreasury = new DeployTreasury();
-        deployTreasury.run(partnerManagerProxy, vehicleRegistryProxy, usdcAddress, adminAddress);
+        deployTreasury.run(partnerManagerProxy, vehicleRegistryProxy, usdcAddress, deployer);
     }
 }

--- a/protocols/evm/script/DeployPartnerManager.s.sol
+++ b/protocols/evm/script/DeployPartnerManager.s.sol
@@ -7,13 +7,11 @@ import "../contracts/PartnerManager.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployPartnerManager is Script {
-    function run() external returns (address) {
-        address deployer = msg.sender;
+    function run(address deployerAddress) external returns (address) {
+        address deployer = deployerAddress;
 
         console.log("Deploying PartnerManager with deployer:", deployer);
         console.log("Deployer balance:", deployer.balance);
-
-        vm.startBroadcast();
 
         // Deploy implementation contract
         PartnerManager partnerImplementation = new PartnerManager();
@@ -36,8 +34,6 @@ contract DeployPartnerManager is Script {
         console.log("Admin has PARTNER_ADMIN_ROLE:", partnerManager.hasRole(keccak256("PARTNER_ADMIN_ROLE"), deployer));
         console.log("Admin has UPGRADER_ROLE:", partnerManager.hasRole(keccak256("UPGRADER_ROLE"), deployer));
         console.log("Initial partner count:", partnerManager.getPartnerCount());
-
-        vm.stopBroadcast();
 
         // Log deployment summary
         console.log("=== Deployment Summary ===");

--- a/protocols/evm/script/DeployRoboshareTokens.s.sol
+++ b/protocols/evm/script/DeployRoboshareTokens.s.sol
@@ -7,13 +7,11 @@ import "../contracts/RoboshareTokens.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployRoboshareTokens is Script {
-    function run() external returns (address) {
-        address deployer = msg.sender;
+    function run(address deployerAddress) external returns (address) {
+        address deployer = deployerAddress;
 
         console.log("Deploying RoboshareTokens with deployer:", deployer);
         console.log("Deployer balance:", deployer.balance);
-
-        vm.startBroadcast();
 
         // Deploy implementation contract
         RoboshareTokens tokenImplementation = new RoboshareTokens();
@@ -34,8 +32,6 @@ contract DeployRoboshareTokens is Script {
         console.log("Admin has MINTER_ROLE:", tokens.hasRole(keccak256("MINTER_ROLE"), deployer));
         console.log("Admin has BURNER_ROLE:", tokens.hasRole(keccak256("BURNER_ROLE"), deployer));
         console.log("Next token ID:", tokens.getNextTokenId());
-
-        vm.stopBroadcast();
 
         // Log deployment summary
         console.log("=== Deployment Summary ===");

--- a/protocols/evm/script/DeployTreasury.s.sol
+++ b/protocols/evm/script/DeployTreasury.s.sol
@@ -12,12 +12,12 @@ contract DeployTreasury is Script {
      * Usage: forge script DeployTreasury --sig "run(address,address,address,address)" $PARTNER_MANAGER_ADDR $VEHICLE_REGISTRY_ADDR $USDC_ADDR $ADMIN_ADDR
      */
     function run(
-        address partnerManagerAddress, 
+        address partnerManagerAddress,
         address vehicleRegistryAddress,
         address usdcAddress,
         address adminAddress
     ) external returns (address) {
-        address deployer = msg.sender;
+        address deployer = adminAddress; // Use admin as deployer for logging consistency
 
         console.log("Deploying Treasury with deployer:", deployer);
         console.log("Deployer balance:", deployer.balance);
@@ -33,17 +33,15 @@ contract DeployTreasury is Script {
         require(usdcAddress != address(0), "USDC address cannot be zero");
         require(adminAddress != address(0), "Admin address cannot be zero");
 
-        vm.startBroadcast();
-
         // Deploy implementation contract
         Treasury treasuryImplementation = new Treasury();
         console.log("Treasury implementation deployed at:", address(treasuryImplementation));
 
         // Prepare initialization data
         bytes memory initData = abi.encodeWithSignature(
-            "initialize(address,address,address,address)", 
+            "initialize(address,address,address,address)",
             adminAddress,
-            partnerManagerAddress, 
+            partnerManagerAddress,
             vehicleRegistryAddress,
             usdcAddress
         );
@@ -63,8 +61,6 @@ contract DeployTreasury is Script {
         console.log("VehicleRegistry reference:", address(treasury.vehicleRegistry()));
         console.log("USDC reference:", address(treasury.usdc()));
         console.log("Total collateral deposited:", treasury.totalCollateralDeposited());
-
-        vm.stopBroadcast();
 
         // Log deployment summary
         console.log("=== Treasury Deployment Summary ===");

--- a/protocols/evm/script/DeployVehicleRegistry.s.sol
+++ b/protocols/evm/script/DeployVehicleRegistry.s.sol
@@ -11,8 +11,11 @@ contract DeployVehicleRegistry is Script {
      * @dev Deploy VehicleRegistry with dependency addresses as parameters
      * Usage: forge script DeployVehicleRegistry --sig "run(address,address)" $TOKENS_ADDR $PARTNER_ADDR
      */
-    function run(address roboshareTokensAddress, address partnerManagerAddress) external returns (address) {
-        address deployer = msg.sender;
+    function run(address roboshareTokensAddress, address partnerManagerAddress, address deployerAddress)
+        external
+        returns (address)
+    {
+        address deployer = deployerAddress;
 
         console.log("Deploying VehicleRegistry with deployer:", deployer);
         console.log("Deployer balance:", deployer.balance);
@@ -23,8 +26,6 @@ contract DeployVehicleRegistry is Script {
         // Validate dependency addresses
         require(roboshareTokensAddress != address(0), "RoboshareTokens address cannot be zero");
         require(partnerManagerAddress != address(0), "PartnerManager address cannot be zero");
-
-        vm.startBroadcast();
 
         // Deploy implementation contract
         VehicleRegistry vehicleImplementation = new VehicleRegistry();
@@ -50,8 +51,6 @@ contract DeployVehicleRegistry is Script {
         console.log("RoboshareTokens reference:", address(vehicleRegistry.roboshareTokens()));
         console.log("PartnerManager reference:", address(vehicleRegistry.partnerManager()));
         console.log("Initial token counter:", vehicleRegistry.getCurrentTokenId());
-
-        vm.stopBroadcast();
 
         // Log deployment summary
         console.log("=== Deployment Summary ===");

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,7 +15,7 @@ const Home: NextPage = () => {
         <div className="px-5">
           <h1 className="text-center">
             <span className="block text-2xl mb-2">Welcome to</span>
-            <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
+            <span className="block text-4xl font-bold">Roboshare Protocol</span>
           </h1>
           <div className="flex justify-center items-center space-x-2 flex-col">
             <p className="my-2 font-medium">Connected Address:</p>
@@ -29,11 +29,7 @@ const Home: NextPage = () => {
             </code>
           </p>
           <p className="text-center text-lg">
-            Edit your smart contract{" "}
-            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
-              YourContract.sol
-            </code>{" "}
-            in{" "}
+            Interact with Roboshare smart contracts: RoboshareTokens, PartnerManager, VehicleRegistry, and Treasury in{" "}
             <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
               protocols/evm/contracts
             </code>

--- a/web/contracts/deployedContracts.ts
+++ b/web/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     RoboshareTokens: {
-      address: "0x700b6a60ce7eaaea56f065753d8dcb9653dbad35",
+      address: "0x7f65d50b2915d5b2ca6cbb879cd5fe940fd44b86",
       abi: [
         {
           type: "constructor",
@@ -1085,84 +1085,11 @@ const deployedContracts = {
         },
       ],
       inheritedFunctions: {},
-      deploymentFile: "run-1757334590.json",
-      deploymentScript: "Deploy.s.sol",
-    },
-    ERC1967Proxy: {
-      address: "0xa15bb66138824a1c7167f5e85b957d04dd34e468",
-      abi: [
-        {
-          type: "constructor",
-          inputs: [
-            {
-              name: "implementation",
-              type: "address",
-              internalType: "address",
-            },
-            {
-              name: "_data",
-              type: "bytes",
-              internalType: "bytes",
-            },
-          ],
-          stateMutability: "payable",
-        },
-        {
-          type: "fallback",
-          stateMutability: "payable",
-        },
-        {
-          type: "event",
-          name: "Upgraded",
-          inputs: [
-            {
-              name: "implementation",
-              type: "address",
-              indexed: true,
-              internalType: "address",
-            },
-          ],
-          anonymous: false,
-        },
-        {
-          type: "error",
-          name: "AddressEmptyCode",
-          inputs: [
-            {
-              name: "target",
-              type: "address",
-              internalType: "address",
-            },
-          ],
-        },
-        {
-          type: "error",
-          name: "ERC1967InvalidImplementation",
-          inputs: [
-            {
-              name: "implementation",
-              type: "address",
-              internalType: "address",
-            },
-          ],
-        },
-        {
-          type: "error",
-          name: "ERC1967NonPayable",
-          inputs: [],
-        },
-        {
-          type: "error",
-          name: "FailedCall",
-          inputs: [],
-        },
-      ],
-      inheritedFunctions: {},
-      deploymentFile: "run-1757334590.json",
+      deploymentFile: "run-1757356925.json",
       deploymentScript: "Deploy.s.sol",
     },
     PartnerManager: {
-      address: "0xb19b36b1456e65e3a6d514d3f715f204bd59f431",
+      address: "0x9ea2f17f8e53d15c6828c2d99651b1ffe9b16e0e",
       abi: [
         {
           type: "constructor",
@@ -1795,11 +1722,11 @@ const deployedContracts = {
         },
       ],
       inheritedFunctions: {},
-      deploymentFile: "run-1757334590.json",
+      deploymentFile: "run-1757356925.json",
       deploymentScript: "Deploy.s.sol",
     },
     VehicleRegistry: {
-      address: "0xe1aa25618fa0c7a1cfdab5d6b456af611873b629",
+      address: "0x3dc1ec9c2867fd75f63f089b5c9760b3d259e07d",
       abi: [
         {
           type: "function",
@@ -2779,11 +2706,11 @@ const deployedContracts = {
         },
       ],
       inheritedFunctions: {},
-      deploymentFile: "run-1757334590.json",
+      deploymentFile: "run-1757356925.json",
       deploymentScript: "Deploy.s.sol",
     },
     Treasury: {
-      address: "0x0c8e79f3534b00d9a3d4a856b665bf4ebc22f2ba",
+      address: "0xc84678cbf0ce9cc53a1cb54c92eafe7ce0350e0a",
       abi: [
         {
           type: "function",
@@ -3650,7 +3577,7 @@ const deployedContracts = {
         },
       ],
       inheritedFunctions: {},
-      deploymentFile: "run-1757334590.json",
+      deploymentFile: "run-1757356925.json",
       deploymentScript: "Deploy.s.sol",
     },
   },


### PR DESCRIPTION
## Summary
Resolves critical issue where the frontend was unable to properly interact with deployed UUPS upgradeable contracts due to ABI generation extracting implementation addresses instead of proxy addresses.

## Problem
- The ABI generation script (`generateTsAbis.js`) was extracting deployment script contract names and implementation addresses from broadcast files
- Frontend was trying to interact with implementation contracts instead of proxy contracts
- This caused `hasRole()` and other state-dependent calls to fail, returning `false` even for valid admin accounts
- Scaffold-ETH 2 was not designed to handle UUPS upgradeable contracts out of the box

## Solution
- ✅ Fixed ABI generation to map implementation addresses to their corresponding proxy addresses
- ✅ Added hardcoded proxy mappings for local development (chain 31337)
- ✅ Updated deployment scripts for consistency and removed redundant broadcast calls
- ✅ Regenerated `deployedContracts.ts` with correct proxy addresses
- ✅ Updated frontend branding to Roboshare Protocol

## Testing
- [x] Verified `hasRole()` now returns `true` for admin account `0xa0Ee7A142d267C1f36714E4a8F75612F20a79720`
- [x] Confirmed frontend can successfully interact with all deployed contracts
- [x] ABI generation script produces correct proxy addresses

## Files Changed
- `protocols/evm/scripts-js/generateTsAbis.js` - Core ABI generation fix
- `protocols/evm/script/*.s.sol` - Deployment script cleanup
- `web/contracts/deployedContracts.ts` - Updated with proxy addresses
- `web/app/page.tsx` - Frontend branding update

## Impact
This enables proper frontend interaction with the deployed Roboshare contracts (RoboshareTokens, PartnerManager, VehicleRegistry, Treasury) and unblocks contract testing and development workflow.