### PR TITLE
fix: address testnet release blockers

### DIFF
--- a/protocols/evm/contracts/Treasury.sol
+++ b/protocols/evm/contracts/Treasury.sol
@@ -174,6 +174,13 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         collateralInfo.lastEventTimestamp = block.timestamp;
     }
 
+    function _reconcileReleasedBaseCollateral(CollateralLib.CollateralInfo storage collateralInfo) internal {
+        uint256 remainingTrackedPrincipal = collateralInfo.baseCollateral + collateralInfo.releasedProtectedBase;
+        collateralInfo.releasedBaseCollateral = collateralInfo.unredeemedBasePrincipal > remainingTrackedPrincipal
+            ? collateralInfo.unredeemedBasePrincipal - remainingTrackedPrincipal
+            : 0;
+    }
+
     function _maybePromoteToEarning(uint256 assetId, uint256 tokenId) internal returns (bool hasSufficientBuffers) {
         hasSufficientBuffers = _hasSufficientBuffers(assetId, tokenId);
         if (router.getAssetStatus(assetId) == AssetLib.AssetStatus.Active && hasSufficientBuffers) {
@@ -240,6 +247,7 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         collateralInfo.unredeemedBasePrincipal = redeemedPrincipal >= collateralInfo.unredeemedBasePrincipal
             ? 0
             : collateralInfo.unredeemedBasePrincipal - redeemedPrincipal;
+        _reconcileReleasedBaseCollateral(collateralInfo);
         totalCollateralDeposited = totalCollateralDeposited >= payout ? totalCollateralDeposited - payout : 0;
         usdc.safeTransfer(holder, payout);
     }

--- a/protocols/evm/scripts-js/coverage-waivers.json
+++ b/protocols/evm/scripts-js/coverage-waivers.json
@@ -81,7 +81,7 @@
   },
   {
     "file": "contracts/Treasury.sol",
-    "line": 288,
+    "line": 296,
     "classification": "via_ir_artifact",
     "reason": "Invalid collateral amount via enableProceeds(assetId) is exercised in tests, but the defensive duplicate check inside _fundCurrentBuffersFor is not mapped reliably under --ir-minimum."
   },

--- a/protocols/evm/test/integration/Treasury.Integration.t.sol
+++ b/protocols/evm/test/integration/Treasury.Integration.t.sol
@@ -467,6 +467,68 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         assertEq(pendingAfter - pendingBefore, initialEarningsPreview);
     }
 
+    function testProcessPrimaryRedemptionRebasesReleasedCollateralForFutureUnlocks() public {
+        _ensureState(SetupState.BuffersFunded);
+
+        CollateralLib.CollateralInfo memory infoInitial = _getCollateralInfo(scenario.assetId);
+        assertTrue(infoInitial.isLocked);
+
+        vm.warp(infoInitial.lockedAt + 182 days);
+        _setupEarningsDistributed(LARGE_EARNINGS_AMOUNT);
+
+        vm.prank(partner1);
+        treasury.releasePartialCollateral(scenario.assetId);
+
+        CollateralLib.CollateralInfo memory infoAfterFirstRelease = _getCollateralInfo(scenario.assetId);
+        assertGt(infoAfterFirstRelease.releasedBaseCollateral, 0);
+
+        uint256 burnAmount = PRIMARY_PURCHASE_AMOUNT / 2;
+        (uint256 redemptionPreview,,,) =
+            marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, burnAmount);
+        assertGt(redemptionPreview, 0);
+
+        vm.prank(address(marketplace));
+        treasury.processPrimaryRedemptionFor(buyer, scenario.revenueTokenId, burnAmount, redemptionPreview);
+
+        CollateralLib.CollateralInfo memory infoAfterRedemption = _getCollateralInfo(scenario.assetId);
+        uint256 expectedReleasedBaseCollateral = infoAfterRedemption.unredeemedBasePrincipal
+            > infoAfterRedemption.baseCollateral + infoAfterRedemption.releasedProtectedBase
+            ? infoAfterRedemption.unredeemedBasePrincipal - infoAfterRedemption.baseCollateral
+                - infoAfterRedemption.releasedProtectedBase
+            : 0;
+
+        assertEq(
+            infoAfterRedemption.releasedBaseCollateral,
+            expectedReleasedBaseCollateral,
+            "Released base collateral should be rebased to the remaining outstanding principal"
+        );
+
+        vm.warp(infoInitial.lockedAt + 365 days);
+        _setupEarningsDistributed(LARGE_EARNINGS_AMOUNT);
+
+        uint256 expectedGrossRelease = CollateralLib.calculateDepreciation(
+            infoAfterRedemption.unredeemedBasePrincipal, block.timestamp - infoInitial.lockedAt
+        );
+        expectedGrossRelease = expectedGrossRelease > expectedReleasedBaseCollateral
+            ? expectedGrossRelease - expectedReleasedBaseCollateral
+            : 0;
+        if (expectedGrossRelease > infoAfterRedemption.baseCollateral) {
+            expectedGrossRelease = infoAfterRedemption.baseCollateral;
+        }
+
+        uint256 expectedProtocolFee = ProtocolLib.calculateProtocolFee(expectedGrossRelease);
+        if (expectedProtocolFee > expectedGrossRelease) {
+            expectedProtocolFee = expectedGrossRelease;
+        }
+        uint256 expectedPartnerRelease = expectedGrossRelease - expectedProtocolFee;
+
+        assertEq(
+            treasury.previewCollateralRelease(scenario.assetId, 0),
+            expectedPartnerRelease,
+            "Future release preview should stay anchored to the remaining tranche after redemption"
+        );
+    }
+
     function testPreviewPrimaryRedemptionPayout() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
 

--- a/web/components/ScaffoldEthAppWithProviders.tsx
+++ b/web/components/ScaffoldEthAppWithProviders.tsx
@@ -11,7 +11,7 @@ import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
-import { wagmiConfig } from "~~/services/web3/wagmiConfig";
+import { getWagmiConfig } from "~~/services/web3/wagmiConfig";
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
@@ -40,12 +40,14 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
   const { resolvedTheme } = useTheme();
   const isDarkMode = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
+  const [wagmiConfig, setWagmiConfig] = useState<ReturnType<typeof getWagmiConfig> | null>(null);
 
   useEffect(() => {
+    setWagmiConfig(getWagmiConfig());
     setMounted(true);
   }, []);
 
-  if (!mounted) {
+  if (!mounted || !wagmiConfig) {
     return null;
   }
 

--- a/web/services/web3/wagmiConfig.tsx
+++ b/web/services/web3/wagmiConfig.tsx
@@ -20,13 +20,15 @@ export const getWagmiConfig = () => {
     return wagmiConfigSingleton;
   }
 
+  const connectors = typeof window === "undefined" ? [] : getWagmiConnectors();
+
   const runtimeEnabledChains = enabledChains.map(chain =>
     chain.id === foundry.id ? getRuntimeLocalChain() : chain,
   ) as [Chain, ...Chain[]];
 
   wagmiConfigSingleton = createConfig({
     chains: runtimeEnabledChains,
-    connectors: getWagmiConnectors(),
+    connectors,
     ssr: true,
     client({ chain }) {
       let rpcFallbacks = [http()];
@@ -57,5 +59,3 @@ export const getWagmiConfig = () => {
 
   return wagmiConfigSingleton;
 };
-
-export const wagmiConfig = getWagmiConfig();


### PR DESCRIPTION
## Summary
- fix treasury collateral release accounting after primary redemptions and add a regression test
- stop eager client wallet connector initialization during Next.js server build
- update the Treasury coverage waiver line number after the helper insertion

## Testing
- env FOUNDRY_OFFLINE=true forge test --match-test testProcessPrimaryRedemptionRebasesReleasedCollateralForFutureUnlocks
- yarn web:build
- yarn web:check-types