### PR TITLE
feat(evm): define PositionManager boundary (ROB-70)

### DIFF
--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
+
+/**
+ * @title PositionManager
+ * @notice Upgradeable boundary contract for position, lock, redemption-epoch, and settlement state.
+ * @dev This scaffold intentionally keeps redemption and settlement responsibilities in the same manager.
+ */
+contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgradeable, IPositionManager {
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 public constant POSITION_ADMIN_ROLE = keccak256("POSITION_ADMIN_ROLE");
+    bytes32 public constant AUTHORIZED_ROUTER_ROLE = keccak256("AUTHORIZED_ROUTER_ROLE");
+    bytes32 public constant AUTHORIZED_MARKETPLACE_ROLE = keccak256("AUTHORIZED_MARKETPLACE_ROLE");
+    bytes32 public constant AUTHORIZED_TREASURY_ROLE = keccak256("AUTHORIZED_TREASURY_ROLE");
+
+    address public registryRouter;
+    address public roboshareTokens;
+    address public partnerManager;
+    address public marketplace;
+    address public treasury;
+    address public usdc;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address admin,
+        address _registryRouter,
+        address _roboshareTokens,
+        address _partnerManager,
+        address _marketplace,
+        address _treasury,
+        address _usdc
+    ) external initializer {
+        if (
+            admin == address(0) || _registryRouter == address(0) || _roboshareTokens == address(0)
+                || _partnerManager == address(0) || _marketplace == address(0) || _treasury == address(0)
+                || _usdc == address(0)
+        ) {
+            revert ZeroAddress();
+        }
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(UPGRADER_ROLE, admin);
+        _grantRole(POSITION_ADMIN_ROLE, admin);
+        _setRoleAdmin(AUTHORIZED_ROUTER_ROLE, POSITION_ADMIN_ROLE);
+        _setRoleAdmin(AUTHORIZED_MARKETPLACE_ROLE, POSITION_ADMIN_ROLE);
+        _setRoleAdmin(AUTHORIZED_TREASURY_ROLE, POSITION_ADMIN_ROLE);
+        _grantRole(AUTHORIZED_ROUTER_ROLE, _registryRouter);
+        _grantRole(AUTHORIZED_MARKETPLACE_ROLE, _marketplace);
+        _grantRole(AUTHORIZED_TREASURY_ROLE, _treasury);
+
+        registryRouter = _registryRouter;
+        roboshareTokens = _roboshareTokens;
+        partnerManager = _partnerManager;
+        marketplace = _marketplace;
+        treasury = _treasury;
+        usdc = _usdc;
+
+        emit PositionManagerInitialized(
+            admin, _registryRouter, _roboshareTokens, _partnerManager, _marketplace, _treasury, _usdc
+        );
+    }
+
+    function updateRegistryRouter(address newRegistryRouter) external onlyRole(POSITION_ADMIN_ROLE) {
+        if (newRegistryRouter == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address oldRegistryRouter = registryRouter;
+        if (oldRegistryRouter != address(0)) {
+            _revokeRole(AUTHORIZED_ROUTER_ROLE, oldRegistryRouter);
+        }
+
+        registryRouter = newRegistryRouter;
+        _grantRole(AUTHORIZED_ROUTER_ROLE, newRegistryRouter);
+        emit RegistryRouterUpdated(oldRegistryRouter, newRegistryRouter);
+    }
+
+    function updateRoboshareTokens(address newRoboshareTokens) external onlyRole(POSITION_ADMIN_ROLE) {
+        if (newRoboshareTokens == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address oldRoboshareTokens = roboshareTokens;
+        roboshareTokens = newRoboshareTokens;
+        emit RoboshareTokensUpdated(oldRoboshareTokens, newRoboshareTokens);
+    }
+
+    function updatePartnerManager(address newPartnerManager) external onlyRole(POSITION_ADMIN_ROLE) {
+        if (newPartnerManager == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address oldPartnerManager = partnerManager;
+        partnerManager = newPartnerManager;
+        emit PartnerManagerUpdated(oldPartnerManager, newPartnerManager);
+    }
+
+    function updateMarketplace(address newMarketplace) external onlyRole(POSITION_ADMIN_ROLE) {
+        if (newMarketplace == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address oldMarketplace = marketplace;
+        if (oldMarketplace != address(0)) {
+            _revokeRole(AUTHORIZED_MARKETPLACE_ROLE, oldMarketplace);
+        }
+
+        marketplace = newMarketplace;
+        _grantRole(AUTHORIZED_MARKETPLACE_ROLE, newMarketplace);
+        emit MarketplaceUpdated(oldMarketplace, newMarketplace);
+    }
+
+    function updateTreasury(address newTreasury) external onlyRole(POSITION_ADMIN_ROLE) {
+        if (newTreasury == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address oldTreasury = treasury;
+        if (oldTreasury != address(0)) {
+            _revokeRole(AUTHORIZED_TREASURY_ROLE, oldTreasury);
+        }
+
+        treasury = newTreasury;
+        _grantRole(AUTHORIZED_TREASURY_ROLE, newTreasury);
+        emit TreasuryUpdated(oldTreasury, newTreasury);
+    }
+
+    function updateUsdc(address newUsdc) external onlyRole(POSITION_ADMIN_ROLE) {
+        if (newUsdc == address(0)) {
+            revert ZeroAddress();
+        }
+
+        address oldUsdc = usdc;
+        usdc = newUsdc;
+        emit UsdcUpdated(oldUsdc, newUsdc);
+    }
+
+    function recordPositionMutation(PositionMutation calldata mutation) external onlyRole(AUTHORIZED_MARKETPLACE_ROLE) {
+        emit PositionMutated(
+            mutation.assetId,
+            mutation.tokenId,
+            mutation.account,
+            mutation.amount,
+            mutation.auxValue,
+            mutation.mutationType,
+            mutation.reason
+        );
+    }
+
+    function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
+        external
+        onlyRole(AUTHORIZED_ROUTER_ROLE)
+    {
+        emit PositionLockUpdated(assetId, tokenId, account, lockUntil, reason);
+    }
+
+    function recordRedemptionEpoch(uint256 tokenId, uint256 epochId, uint256 redeemableSupply, bytes32 reason)
+        external
+        onlyRole(AUTHORIZED_TREASURY_ROLE)
+    {
+        emit RedemptionEpochUpdated(tokenId, epochId, redeemableSupply, reason);
+    }
+
+    function recordSettlement(
+        uint256 assetId,
+        uint256 epochId,
+        uint256 settlementAmount,
+        uint256 settlementPerToken,
+        bytes32 reason
+    ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        emit SettlementConfigured(assetId, epochId, settlementAmount, settlementPerToken, reason);
+    }
+
+    function recordSettlementClaim(
+        uint256 assetId,
+        uint256 tokenId,
+        address account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        emit SettlementClaimRecorded(assetId, tokenId, account, burnAmount, payout, reason);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
+}

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title IPositionManager
+ * @notice Canonical manager boundary for position, lock, redemption, and settlement state.
+ * @dev Redemption and settlement are intentionally kept in this same manager for the split refactor.
+ *
+ * Boundary decisions frozen for downstream rewiring:
+ * - RoboshareTokens remains the ERC1155 balance, supply, and token metadata surface.
+ * - Asset registries remain responsible for protocol-critical asset lifecycle state.
+ * - Treasury remains the cash, collateral, earnings-effect, and withdrawal-credit layer.
+ * - PositionManager owns holder positions, listing locks, redemption epochs, and settlement claim state.
+ */
+interface IPositionManager {
+    enum PositionMutationType {
+        Mint,
+        Burn,
+        TransferIn,
+        TransferOut,
+        Lock,
+        Unlock,
+        Redemption,
+        SettlementClaim
+    }
+
+    struct PositionMutation {
+        uint256 assetId;
+        uint256 tokenId;
+        address account;
+        uint256 amount;
+        uint256 auxValue;
+        PositionMutationType mutationType;
+        bytes32 reason;
+    }
+
+    event PositionManagerInitialized(
+        address indexed admin,
+        address indexed registryRouter,
+        address indexed roboshareTokens,
+        address partnerManager,
+        address marketplace,
+        address treasury,
+        address usdc
+    );
+
+    event RegistryRouterUpdated(address indexed oldAddress, address indexed newAddress);
+    event RoboshareTokensUpdated(address indexed oldAddress, address indexed newAddress);
+    event PartnerManagerUpdated(address indexed oldAddress, address indexed newAddress);
+    event MarketplaceUpdated(address indexed oldAddress, address indexed newAddress);
+    event TreasuryUpdated(address indexed oldAddress, address indexed newAddress);
+    event UsdcUpdated(address indexed oldAddress, address indexed newAddress);
+
+    event PositionMutated(
+        uint256 indexed assetId,
+        uint256 indexed tokenId,
+        address indexed account,
+        uint256 amount,
+        uint256 auxValue,
+        PositionMutationType mutationType,
+        bytes32 reason
+    );
+
+    event PositionLockUpdated(
+        uint256 indexed assetId, uint256 indexed tokenId, address indexed account, uint256 lockUntil, bytes32 reason
+    );
+
+    event RedemptionEpochUpdated(
+        uint256 indexed tokenId, uint256 indexed epochId, uint256 redeemableSupply, bytes32 reason
+    );
+
+    event SettlementConfigured(
+        uint256 indexed assetId,
+        uint256 indexed epochId,
+        uint256 settlementAmount,
+        uint256 settlementPerToken,
+        bytes32 reason
+    );
+
+    event SettlementClaimRecorded(
+        uint256 indexed assetId,
+        uint256 indexed tokenId,
+        address indexed account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    );
+
+    error ZeroAddress();
+
+    function initialize(
+        address admin,
+        address registryRouter,
+        address roboshareTokens,
+        address partnerManager,
+        address marketplace,
+        address treasury,
+        address usdc
+    ) external;
+
+    function UPGRADER_ROLE() external view returns (bytes32);
+    function POSITION_ADMIN_ROLE() external view returns (bytes32);
+    function AUTHORIZED_ROUTER_ROLE() external view returns (bytes32);
+    function AUTHORIZED_MARKETPLACE_ROLE() external view returns (bytes32);
+    function AUTHORIZED_TREASURY_ROLE() external view returns (bytes32);
+
+    function registryRouter() external view returns (address);
+    function roboshareTokens() external view returns (address);
+    function partnerManager() external view returns (address);
+    function marketplace() external view returns (address);
+    function treasury() external view returns (address);
+    function usdc() external view returns (address);
+
+    function updateRegistryRouter(address newRegistryRouter) external;
+    function updateRoboshareTokens(address newRoboshareTokens) external;
+    function updatePartnerManager(address newPartnerManager) external;
+    function updateMarketplace(address newMarketplace) external;
+    function updateTreasury(address newTreasury) external;
+    function updateUsdc(address newUsdc) external;
+
+    function recordPositionMutation(PositionMutation calldata mutation) external;
+
+    function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
+        external;
+
+    function recordRedemptionEpoch(uint256 tokenId, uint256 epochId, uint256 redeemableSupply, bytes32 reason) external;
+
+    function recordSettlement(
+        uint256 assetId,
+        uint256 epochId,
+        uint256 settlementAmount,
+        uint256 settlementPerToken,
+        bytes32 reason
+    ) external;
+
+    function recordSettlementClaim(
+        uint256 assetId,
+        uint256 tokenId,
+        address account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    ) external;
+}

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Test } from "forge-std/Test.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
+import { PositionManager } from "../../contracts/PositionManager.sol";
+
+contract PositionManagerTest is Test {
+    PositionManager public positionManager;
+
+    address public admin = makeAddr("admin");
+    address public registryRouter = makeAddr("registryRouter");
+    address public roboshareTokens = makeAddr("roboshareTokens");
+    address public partnerManager = makeAddr("partnerManager");
+    address public marketplace = makeAddr("marketplace");
+    address public treasury = makeAddr("treasury");
+    address public usdc = makeAddr("usdc");
+    address public unauthorized = makeAddr("unauthorized");
+
+    bytes32 private constant PRIMARY_REASON = keccak256("primary");
+    bytes32 private constant LISTING_REASON = keccak256("listing");
+    bytes32 private constant REDEEM_REASON = keccak256("redeem");
+    bytes32 private constant SETTLE_REASON = keccak256("settle");
+    bytes32 private constant CLAIM_REASON = keccak256("claim");
+
+    event PositionMutated(
+        uint256 indexed assetId,
+        uint256 indexed tokenId,
+        address indexed account,
+        uint256 amount,
+        uint256 auxValue,
+        IPositionManager.PositionMutationType mutationType,
+        bytes32 reason
+    );
+
+    event PositionLockUpdated(
+        uint256 indexed assetId, uint256 indexed tokenId, address indexed account, uint256 lockUntil, bytes32 reason
+    );
+
+    event RedemptionEpochUpdated(
+        uint256 indexed tokenId, uint256 indexed epochId, uint256 redeemableSupply, bytes32 reason
+    );
+
+    event SettlementConfigured(
+        uint256 indexed assetId,
+        uint256 indexed epochId,
+        uint256 settlementAmount,
+        uint256 settlementPerToken,
+        bytes32 reason
+    );
+
+    event SettlementClaimRecorded(
+        uint256 indexed assetId,
+        uint256 indexed tokenId,
+        address indexed account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    );
+
+    function setUp() public {
+        positionManager = _deployPositionManager(
+            admin, registryRouter, roboshareTokens, partnerManager, marketplace, treasury, usdc
+        );
+    }
+
+    function testInitialization() public view {
+        assertEq(positionManager.registryRouter(), registryRouter);
+        assertEq(positionManager.roboshareTokens(), roboshareTokens);
+        assertEq(positionManager.partnerManager(), partnerManager);
+        assertEq(positionManager.marketplace(), marketplace);
+        assertEq(positionManager.treasury(), treasury);
+        assertEq(positionManager.usdc(), usdc);
+
+        assertEq(positionManager.UPGRADER_ROLE(), keccak256("UPGRADER_ROLE"));
+        assertEq(positionManager.POSITION_ADMIN_ROLE(), keccak256("POSITION_ADMIN_ROLE"));
+        assertEq(positionManager.AUTHORIZED_ROUTER_ROLE(), keccak256("AUTHORIZED_ROUTER_ROLE"));
+        assertEq(positionManager.AUTHORIZED_MARKETPLACE_ROLE(), keccak256("AUTHORIZED_MARKETPLACE_ROLE"));
+        assertEq(positionManager.AUTHORIZED_TREASURY_ROLE(), keccak256("AUTHORIZED_TREASURY_ROLE"));
+
+        assertTrue(positionManager.hasRole(positionManager.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(positionManager.hasRole(positionManager.UPGRADER_ROLE(), admin));
+        assertTrue(positionManager.hasRole(positionManager.POSITION_ADMIN_ROLE(), admin));
+        assertTrue(positionManager.hasRole(positionManager.AUTHORIZED_ROUTER_ROLE(), registryRouter));
+        assertTrue(positionManager.hasRole(positionManager.AUTHORIZED_MARKETPLACE_ROLE(), marketplace));
+        assertTrue(positionManager.hasRole(positionManager.AUTHORIZED_TREASURY_ROLE(), treasury));
+
+        assertEq(
+            positionManager.getRoleAdmin(positionManager.AUTHORIZED_ROUTER_ROLE()),
+            positionManager.POSITION_ADMIN_ROLE()
+        );
+        assertEq(
+            positionManager.getRoleAdmin(positionManager.AUTHORIZED_MARKETPLACE_ROLE()),
+            positionManager.POSITION_ADMIN_ROLE()
+        );
+        assertEq(
+            positionManager.getRoleAdmin(positionManager.AUTHORIZED_TREASURY_ROLE()),
+            positionManager.POSITION_ADMIN_ROLE()
+        );
+    }
+
+    function testInitializationZeroAddress() public {
+        PositionManager implementation = new PositionManager();
+
+        vm.expectRevert(IPositionManager.ZeroAddress.selector);
+        new ERC1967Proxy(
+            address(implementation),
+            abi.encodeCall(
+                PositionManager.initialize,
+                (admin, registryRouter, roboshareTokens, partnerManager, address(0), treasury, usdc)
+            )
+        );
+    }
+
+    function testPositionAdminCanRotateDependencyRoles() public {
+        address newRouter = makeAddr("newRouter");
+        address newMarketplace = makeAddr("newMarketplace");
+        address newTreasury = makeAddr("newTreasury");
+
+        vm.startPrank(admin);
+        positionManager.updateRegistryRouter(newRouter);
+        positionManager.updateMarketplace(newMarketplace);
+        positionManager.updateTreasury(newTreasury);
+        vm.stopPrank();
+
+        assertEq(positionManager.registryRouter(), newRouter);
+        assertEq(positionManager.marketplace(), newMarketplace);
+        assertEq(positionManager.treasury(), newTreasury);
+
+        assertFalse(positionManager.hasRole(positionManager.AUTHORIZED_ROUTER_ROLE(), registryRouter));
+        assertFalse(positionManager.hasRole(positionManager.AUTHORIZED_MARKETPLACE_ROLE(), marketplace));
+        assertFalse(positionManager.hasRole(positionManager.AUTHORIZED_TREASURY_ROLE(), treasury));
+        assertTrue(positionManager.hasRole(positionManager.AUTHORIZED_ROUTER_ROLE(), newRouter));
+        assertTrue(positionManager.hasRole(positionManager.AUTHORIZED_MARKETPLACE_ROLE(), newMarketplace));
+        assertTrue(positionManager.hasRole(positionManager.AUTHORIZED_TREASURY_ROLE(), newTreasury));
+    }
+
+    function testUpdateMarketplaceZeroAddress() public {
+        vm.expectRevert(IPositionManager.ZeroAddress.selector);
+        vm.prank(admin);
+        positionManager.updateMarketplace(address(0));
+    }
+
+    function testUpdateMarketplaceUnauthorizedCaller() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                unauthorized,
+                positionManager.POSITION_ADMIN_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        positionManager.updateMarketplace(makeAddr("newMarketplace"));
+    }
+
+    function testAuthorizedMarketplaceCanRecordPositionMutation() public {
+        IPositionManager.PositionMutation memory mutation = IPositionManager.PositionMutation({
+            assetId: 1,
+            tokenId: 2,
+            account: makeAddr("holder"),
+            amount: 3,
+            auxValue: 4,
+            mutationType: IPositionManager.PositionMutationType.Mint,
+            reason: PRIMARY_REASON
+        });
+
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit PositionMutated(
+            mutation.assetId,
+            mutation.tokenId,
+            mutation.account,
+            mutation.amount,
+            mutation.auxValue,
+            mutation.mutationType,
+            mutation.reason
+        );
+
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(mutation);
+    }
+
+    function testUnauthorizedCallerCannotRecordPositionMutation() public {
+        IPositionManager.PositionMutation memory mutation = IPositionManager.PositionMutation({
+            assetId: 1,
+            tokenId: 2,
+            account: makeAddr("holder"),
+            amount: 3,
+            auxValue: 4,
+            mutationType: IPositionManager.PositionMutationType.Mint,
+            reason: PRIMARY_REASON
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                unauthorized,
+                positionManager.AUTHORIZED_MARKETPLACE_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        positionManager.recordPositionMutation(mutation);
+    }
+
+    function testAuthorizedRouterCanRecordPositionLock() public {
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit PositionLockUpdated(1, 2, makeAddr("holder"), block.timestamp + 1 days, LISTING_REASON);
+
+        vm.prank(registryRouter);
+        positionManager.recordPositionLock(1, 2, makeAddr("holder"), block.timestamp + 1 days, LISTING_REASON);
+    }
+
+    function testAuthorizedTreasuryCanRecordRedemptionAndSettlementEvents() public {
+        vm.startPrank(treasury);
+
+        vm.expectEmit(true, true, false, true, address(positionManager));
+        emit RedemptionEpochUpdated(2, 1, 100, REDEEM_REASON);
+        positionManager.recordRedemptionEpoch(2, 1, 100, REDEEM_REASON);
+
+        vm.expectEmit(true, true, false, true, address(positionManager));
+        emit SettlementConfigured(1, 1, 1000, 10, SETTLE_REASON);
+        positionManager.recordSettlement(1, 1, 1000, 10, SETTLE_REASON);
+
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit SettlementClaimRecorded(1, 2, makeAddr("holder"), 20, 200, CLAIM_REASON);
+        positionManager.recordSettlementClaim(1, 2, makeAddr("holder"), 20, 200, CLAIM_REASON);
+
+        vm.stopPrank();
+    }
+
+    function testUpgradeAuthorizedCaller() public {
+        PositionManager newImplementation = new PositionManager();
+
+        vm.prank(admin);
+        positionManager.upgradeToAndCall(address(newImplementation), "");
+    }
+
+    function testUpgradeUnauthorizedCaller() public {
+        PositionManager newImplementation = new PositionManager();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, unauthorized, positionManager.UPGRADER_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        positionManager.upgradeToAndCall(address(newImplementation), "");
+    }
+
+    function _deployPositionManager(
+        address _admin,
+        address _registryRouter,
+        address _roboshareTokens,
+        address _partnerManager,
+        address _marketplace,
+        address _treasury,
+        address _usdc
+    ) internal returns (PositionManager) {
+        PositionManager implementation = new PositionManager();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            abi.encodeCall(
+                PositionManager.initialize,
+                (_admin, _registryRouter, _roboshareTokens, _partnerManager, _marketplace, _treasury, _usdc)
+            )
+        );
+
+        return PositionManager(address(proxy));
+    }
+}


### PR DESCRIPTION
## Summary

- Define the `IPositionManager` interface and upgradeable `PositionManager` scaffold for the position-manager split.
- Add explicit marketplace dependency wiring, role seeding, role rotation, and event surface for downstream rewiring.
- Record the stable ownership boundary: tokens own ERC1155 balances/metadata, registries own protocol-critical lifecycle state, Treasury owns cash/collateral/withdrawals, and PositionManager owns positions, locks, redemption epochs, and settlement claim state.
- Add focused unit coverage for initialization, role administration, authorized event emitters, dependency rotation, and UUPS authorization.

## Validation

- `forge test --offline --match-path test/unit/PositionManager.t.sol`
- `yarn evm:compile`

Note: `yarn evm:compile` succeeded with a sandbox-only Foundry warning about writing `~/.foundry/cache/signatures`.