### PR TITLE
feat(evm): define token metadata boundary (ROB-96)

### DIFF
--- a/docs/evm-token-metadata-boundary.md
+++ b/docs/evm-token-metadata-boundary.md
@@ -1,0 +1,70 @@
+# EVM token/registry metadata boundary (ROB-96)
+
+This document defines the metadata model between `VehicleRegistry` and `RoboshareTokens`.
+
+## Canonical model
+
+- **Registry-owned protocol state (trusted on-chain):**
+  - `assetId` lifecycle + settlement state
+  - `vinHash` as optional uniqueness anchor (`bytes32`)
+  - asset NFT metadata URI pointer (`ipfs://...`)
+  - paired revenue-token metadata URI pointer (`ipfs://...`)
+- **Transitional legacy state:**
+  - `assetValue` still exists because current pool creation derives issuance from it.
+  - The target boundary does not treat appraisal/display value as registry business metadata or as the source of pool sizing.
+  - ROB-97 owns removing `assetValue`-driven issuance in favor of explicit pool-size terms such as `maxSupply`.
+- **Protocol/economic terms (trusted on-chain when contracts use them):**
+  - token price or current price/NAV, depending on the final pricing model
+  - maturity date
+  - revenue share basis points
+  - target yield basis points
+  - max supply
+  - immediate proceeds flag
+  - protection flag
+- **Presentation-only metadata (untrusted JSON at URI):**
+  - make/model/year
+  - images/media
+  - odometer/condition/history
+  - display copies of protocol/economic terms
+  - any UI decoration labels
+
+## URI behavior
+
+- `VehicleRegistry` now decodes registration payload as:
+  - `abi.encode(string vin, string assetMetadataURI, string revenueTokenMetadataURI)`
+- During registration, it stores `vinHash` plus separate asset NFT and revenue-token metadata pointers, then sets each token URI in `RoboshareTokens`:
+  - asset NFT ID URI = `assetMetadataURI`
+  - paired revenue-token ID URI = `revenueTokenMetadataURI`
+- `updateVehicleMetadata(assetId, assetMetadataURI, revenueTokenMetadataURI)` updates both pointers explicitly and may only be called by the authorized partner that owns the asset NFT.
+- `RoboshareTokens.uri(id)` returns per-token canonical URI if explicitly set; otherwise it falls back to ERC1155 base URI behavior.
+
+## Metadata JSON shapes
+
+Asset NFT metadata describes the underlying asset for wallets, web, marketplaces, and indexers:
+
+- `name`, `description`, `image`
+- optional gallery, video, or media fields
+- make/model/year and other display attributes
+- VIN only if product and privacy needs allow it; otherwise keep only `vinHash` on-chain
+- odometer, condition, inspection summaries, history, and other presentation/business fields
+- optional `external_url` only when a stable app route exists
+
+Revenue token metadata describes the revenue/claim-unit token:
+
+- `name`, `description`, `image`
+- linkage to the underlying `assetId` / asset NFT
+- display copies of authoritative on-chain pool/product terms
+- optional `external_url` only when a stable app route exists
+
+The same JSON document should not be reused for both token IDs by default. A shared document is acceptable only when it is intentionally designed as a typed multi-view document and consumers can reliably distinguish the asset view from the revenue-token view.
+
+## Transitional dependencies
+
+- ROB-84 owns updating web registration payloads and reads to the new metadata-pointer shape. Until ROB-84 lands, web incompatibility on this integration branch is expected.
+- ROB-85 owns updating subgraph ABI/event handling for the slimmed registry metadata model. Until ROB-85 lands, subgraph incompatibility on this integration branch is expected.
+
+## Why this split
+
+The split makes token metadata a token-layer concern while keeping registries thin and protocol-focused. Consumers should resolve rich display content from token metadata URIs rather than treating registry structs as a required display API.
+
+Token URI JSON is presentation data only. Protocol behavior must use authoritative on-chain state or an explicitly trusted oracle/accounting/governance path.

--- a/protocols/evm/contracts/Libraries.sol
+++ b/protocols/evm/contracts/Libraries.sol
@@ -216,29 +216,21 @@ library AssetLib {
 }
 
 /**
- * @dev Vehicle-related data structures and functions
- * Hybrid storage: immutable data on-chain, dynamic data on IPFS
+ * @dev Vehicle-related data structures and functions.
+ * Keeps only protocol anchors and token-facing metadata pointers on-chain.
  */
 library VehicleLib {
     // Errors
     error InvalidVINLength();
-    error InvalidMake();
-    error InvalidModel();
-    error InvalidYear();
     error InvalidMetadataURI();
 
     /**
-     * @dev Immutable vehicle information stored on-chain
-     * Set once during registration, never changes
+     * @dev Protocol-trusted vehicle identity anchor plus token metadata pointers.
      */
     struct VehicleInfo {
-        string vin; // Vehicle Identification Number
-        string make; // e.g., "Tesla", "Ford"
-        string model; // e.g., "Model S", "F-150"
-        uint256 year; // Manufacturing year
-        uint256 manufacturerId; // Partner's manufacturer ID
-        string optionCodes; // e.g., "P90D,AP1,SUBW"
-        string dynamicMetadataURI; // IPFS URI for changing data (odometer, etc.)
+        bytes32 vinHash; // Uniqueness anchor for vehicle identity
+        string assetMetadataURI; // Asset NFT presentation metadata pointer
+        string revenueTokenMetadataURI; // Revenue-token presentation metadata pointer
     }
 
     /**
@@ -247,114 +239,73 @@ library VehicleLib {
     struct Vehicle {
         uint256 vehicleId; // Unique vehicle identifier
         AssetLib.AssetInfo assetInfo; // Standard asset management
-        VehicleInfo vehicleInfo; // Immutable data + IPFS metadata URI
+        VehicleInfo vehicleInfo; // Uniqueness anchor + metadata pointers
     }
 
     /**
-     * @dev Initialize complete vehicle with asset info and vehicle-specific data
+     * @dev Initialize complete vehicle with asset info and token metadata pointers.
      */
     function initializeVehicle(
         Vehicle storage vehicle,
         uint256 vehicleId,
         uint256 assetValue,
-        string memory vin,
-        string memory make,
-        string memory model,
-        uint256 year,
-        uint256 manufacturerId,
-        string memory optionCodes,
-        string memory dynamicMetadataURI
+        bytes32 vinHash,
+        string memory assetMetadataURI,
+        string memory revenueTokenMetadataURI
     ) internal {
-        // Set vehicle ID
         vehicle.vehicleId = vehicleId;
-
-        // Initialize asset info
         AssetLib.initializeAssetInfo(vehicle.assetInfo, assetValue);
-
-        // Initialize vehicle-specific info
-        initializeVehicleInfo(
-            vehicle.vehicleInfo, vin, make, model, year, manufacturerId, optionCodes, dynamicMetadataURI
-        );
+        initializeVehicleInfo(vehicle.vehicleInfo, vinHash, assetMetadataURI, revenueTokenMetadataURI);
     }
 
     /**
-     * @dev Initialize vehicle info with validation
+     * @dev Build VIN hash and validate VIN format.
      */
-    function initializeVehicleInfo(
-        VehicleInfo storage info,
-        string memory vin,
-        string memory make,
-        string memory model,
-        uint256 year,
-        uint256 manufacturerId,
-        string memory optionCodes,
-        string memory dynamicMetadataURI
-    ) internal {
-        // Validation
+    function toVINHash(string memory vin) internal pure returns (bytes32) {
         if (bytes(vin).length < 10 || bytes(vin).length > 17) {
             revert InvalidVINLength();
         }
-        if (bytes(make).length == 0) {
-            revert InvalidMake();
+        return keccak256(bytes(vin));
+    }
+
+    /**
+     * @dev Initialize vehicle info with validation.
+     */
+    function initializeVehicleInfo(
+        VehicleInfo storage info,
+        bytes32 vinHash,
+        string memory assetMetadataURI,
+        string memory revenueTokenMetadataURI
+    ) internal {
+        if (vinHash == bytes32(0)) {
+            revert InvalidVINLength();
         }
-        if (bytes(model).length == 0) {
-            revert InvalidModel();
-        }
-        if (year < 1990 || year > 2030) {
-            revert InvalidYear();
-        }
-        if (!ProtocolLib.isValidIPFSURI(dynamicMetadataURI)) {
+        _validateMetadataURI(assetMetadataURI);
+        _validateMetadataURI(revenueTokenMetadataURI);
+
+        info.vinHash = vinHash;
+        info.assetMetadataURI = assetMetadataURI;
+        info.revenueTokenMetadataURI = revenueTokenMetadataURI;
+    }
+
+    /**
+     * @dev Update token metadata pointers.
+     */
+    function updateMetadata(
+        VehicleInfo storage info,
+        string memory assetMetadataURI,
+        string memory revenueTokenMetadataURI
+    ) internal {
+        _validateMetadataURI(assetMetadataURI);
+        _validateMetadataURI(revenueTokenMetadataURI);
+        info.assetMetadataURI = assetMetadataURI;
+        info.revenueTokenMetadataURI = revenueTokenMetadataURI;
+    }
+
+    function _validateMetadataURI(string memory metadataURI) private pure {
+        if (!ProtocolLib.isValidIPFSURI(metadataURI)) {
             revert InvalidMetadataURI();
         }
-
-        // Set values
-        info.vin = vin;
-        info.make = make;
-        info.model = model;
-        info.year = year;
-        info.manufacturerId = manufacturerId;
-        info.optionCodes = optionCodes;
-        info.dynamicMetadataURI = dynamicMetadataURI;
-    }
-
-    /**
-     * @dev Update dynamic metadata URI (for IPFS data changes like odometer)
-     */
-    function updateDynamicMetadata(VehicleInfo storage info, string memory newMetadataURI) internal {
-        if (!ProtocolLib.isValidIPFSURI(newMetadataURI)) {
-            revert InvalidMetadataURI();
-        }
-        info.dynamicMetadataURI = newMetadataURI;
-    }
-
-    /**
-     * @dev Get vehicle display name for UI/events
-     */
-    function getDisplayName(VehicleInfo storage info) internal view returns (string memory) {
-        return string(abi.encodePacked(info.make, " ", info.model, " ", _uint256ToString(info.year)));
-    }
-
-    /**
-     * @dev Convert uint256 to string (internal utility)
-     */
-    function _uint256ToString(uint256 value) private pure returns (string memory) {
-        if (value == 0) {
-            return "0";
-        }
-        uint256 temp = value;
-        uint256 digits;
-        while (temp != 0) {
-            digits++;
-            temp /= 10;
-        }
-        bytes memory buffer = new bytes(digits);
-        while (value != 0) {
-            digits -= 1;
-            // forge-lint: disable-next-line(unsafe-typecast)
-            buffer[digits] = bytes1(uint8(48 + uint8(value % 10)));
-            value /= 10;
-        }
-        return string(buffer);
     }
 }
 

--- a/protocols/evm/contracts/RoboshareTokens.sol
+++ b/protocols/evm/contracts/RoboshareTokens.sol
@@ -35,6 +35,7 @@ contract RoboshareTokens is
     error InvalidLockAmount();
     error InsufficientUnlockedBalance();
     error InsufficientLockedBalance();
+    error EmptyMetadataURI();
 
     // Events
     event RevenueTokenPositionsUpdated(
@@ -54,11 +55,13 @@ contract RoboshareTokens is
     event PrimaryRedemptionStateUpdated(
         uint256 indexed revenueTokenId, uint256 redemptionEpoch, uint256 epochSupply, uint256 backedPrincipal
     );
+    event TokenMetadataURISet(uint256 indexed tokenId, string metadataURI);
 
     // Token state
     uint256 private _tokenIdCounter;
     mapping(uint256 => TokenLib.TokenInfo) private _revenueTokenInfos;
     mapping(address => mapping(uint256 => uint256)) private _lockedRevenueTokenAmounts;
+    mapping(uint256 => string) private _tokenMetadataURIs;
     bool private _currentEpochBurnActive;
     address private _currentEpochBurnHolder;
     uint256 private _currentEpochBurnTokenId;
@@ -193,6 +196,30 @@ contract RoboshareTokens is
      */
     function setURI(string memory newuri) external onlyRole(URI_SETTER_ROLE) {
         _setURI(newuri);
+    }
+
+    /**
+     * @dev Sets metadata URI for a specific token ID.
+     * Can be called by token minters (registries) and URI setters (admin/ops).
+     */
+    function setTokenMetadataURI(uint256 tokenId, string calldata metadataURI) external {
+        if (!hasRole(URI_SETTER_ROLE, msg.sender) && !hasRole(MINTER_ROLE, msg.sender)) {
+            revert AccessControlUnauthorizedAccount(msg.sender, URI_SETTER_ROLE);
+        }
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+        _tokenMetadataURIs[tokenId] = metadataURI;
+        emit TokenMetadataURISet(tokenId, metadataURI);
+    }
+
+    /**
+     * @dev Returns metadata URI for a token ID if present, else falls back to ERC1155 base URI pattern.
+     */
+    function uri(uint256 id) public view override returns (string memory) {
+        string memory tokenMetadataURI = _tokenMetadataURIs[id];
+        if (bytes(tokenMetadataURI).length > 0) {
+            return tokenMetadataURI;
+        }
+        return super.uri(id);
     }
 
     /**

--- a/protocols/evm/contracts/VehicleRegistry.sol
+++ b/protocols/evm/contracts/VehicleRegistry.sol
@@ -11,13 +11,11 @@ import { PartnerManager } from "./PartnerManager.sol";
 import { RegistryRouter } from "./RegistryRouter.sol";
 
 /**
- * @dev Vehicle registration and management with IPFS metadata integration
+ * @dev Vehicle registration and management with token metadata pointers
  * Coordinates with RoboshareTokens for minting and PartnerManager for authorization
  * Implements IAssetsRegistry for generic asset management capabilities
  */
 contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeable, IAssetRegistry {
-    using VehicleLib for VehicleLib.VehicleInfo;
-
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     bytes32 public constant ROUTER_ROLE = keccak256("ROUTER_ROLE");
 
@@ -28,7 +26,7 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
 
     // Vehicle storage
     mapping(uint256 => VehicleLib.Vehicle) public vehicles;
-    mapping(string => bool) public vinExists; // VIN uniqueness tracking
+    mapping(bytes32 => bool) public vinHashExists; // VIN hash uniqueness tracking
 
     // Errors
     error ZeroAddress();
@@ -37,9 +35,9 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
     error OutstandingTokensHeldByOthers();
 
     // Events
-    event VehicleRegistered(uint256 indexed vehicleId, address indexed partner, string vin);
+    event VehicleRegistered(uint256 indexed vehicleId, address indexed partner, bytes32 indexed vinHash);
 
-    event VehicleMetadataUpdated(uint256 indexed vehicleId, string newMetadataURI);
+    event VehicleMetadataUpdated(uint256 indexed vehicleId, string assetMetadataURI, string revenueTokenMetadataURI);
     event RoboshareTokensUpdated(address indexed oldAddress, address indexed newAddress);
     event PartnerManagerUpdated(address indexed oldAddress, address indexed newAddress);
     event RouterUpdated(address indexed oldAddress, address indexed newAddress);
@@ -110,20 +108,12 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
     // View Functions
 
     /**
-     * @dev Get vehicle information
+     * @dev Get protocol-trusted vehicle information and token metadata pointers.
      */
     function getVehicleInfo(uint256 vehicleId)
         external
         view
-        returns (
-            string memory vin,
-            string memory make,
-            string memory model,
-            uint256 year,
-            uint256 manufacturerId,
-            string memory optionCodes,
-            string memory dynamicMetadataURI
-        )
+        returns (bytes32 vinHash, string memory assetMetadataURI, string memory revenueTokenMetadataURI)
     {
         VehicleLib.Vehicle storage vehicle = vehicles[vehicleId];
         if (vehicle.vehicleId == 0) {
@@ -131,20 +121,7 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
         }
 
         VehicleLib.VehicleInfo storage info = vehicle.vehicleInfo;
-        return
-            (info.vin, info.make, info.model, info.year, info.manufacturerId, info.optionCodes, info.dynamicMetadataURI);
-    }
-
-    /**
-     * @dev Get vehicle display name
-     */
-    function getVehicleDisplayName(uint256 vehicleId) external view returns (string memory) {
-        VehicleLib.Vehicle storage vehicle = vehicles[vehicleId];
-        if (vehicle.vehicleId == 0) {
-            revert VehicleDoesNotExist();
-        }
-
-        return VehicleLib.getDisplayName(vehicle.vehicleInfo);
+        return (info.vinHash, info.assetMetadataURI, info.revenueTokenMetadataURI);
     }
 
     // IAssetRegistry implementation
@@ -236,17 +213,24 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
     }
 
     /**
-     * @dev Update dynamic metadata URI for a vehicle
+     * @dev Update asset NFT and revenue-token metadata pointers for a vehicle.
      */
-    function updateVehicleMetadata(uint256 vehicleId, string memory newMetadataURI) external onlyAuthorizedPartner {
+    function updateVehicleMetadata(
+        uint256 vehicleId,
+        string memory assetMetadataURI,
+        string memory revenueTokenMetadataURI
+    ) external {
         VehicleLib.Vehicle storage vehicle = vehicles[vehicleId];
         if (vehicle.vehicleId == 0) {
             revert VehicleDoesNotExist();
         }
+        _requireAuthorizedAssetOwner(msg.sender, vehicleId);
 
-        VehicleLib.updateDynamicMetadata(vehicle.vehicleInfo, newMetadataURI);
+        VehicleLib.updateMetadata(vehicle.vehicleInfo, assetMetadataURI, revenueTokenMetadataURI);
+        roboshareTokens.setTokenMetadataURI(vehicleId, assetMetadataURI);
+        roboshareTokens.setTokenMetadataURI(TokenLib.getTokenIdFromAssetId(vehicleId), revenueTokenMetadataURI);
 
-        emit VehicleMetadataUpdated(vehicleId, newMetadataURI);
+        emit VehicleMetadataUpdated(vehicleId, assetMetadataURI, revenueTokenMetadataURI);
     }
 
     /**
@@ -537,29 +521,23 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
         internal
         returns (uint256 vehicleId, uint256 revenueTokenId)
     {
-        (
-            string memory vin,
-            string memory make,
-            string memory model,
-            uint256 year,
-            uint256 manufacturerId,
-            string memory optionCodes,
-            string memory dynamicMetadataURI
-        ) = abi.decode(data, (string, string, string, uint256, uint256, string, string));
+        (string memory vin, string memory assetMetadataURI, string memory revenueTokenMetadataURI) =
+            abi.decode(data, (string, string, string));
 
-        if (vinExists[vin]) revert VehicleAlreadyExists();
+        bytes32 vinHash = VehicleLib.toVINHash(vin);
+        if (vinHashExists[vinHash]) revert VehicleAlreadyExists();
 
         (vehicleId, revenueTokenId) = router.reserveNextTokenIdPair();
 
         VehicleLib.Vehicle storage vehicle = vehicles[vehicleId];
-        VehicleLib.initializeVehicle(
-            vehicle, vehicleId, assetValue, vin, make, model, year, manufacturerId, optionCodes, dynamicMetadataURI
-        );
+        VehicleLib.initializeVehicle(vehicle, vehicleId, assetValue, vinHash, assetMetadataURI, revenueTokenMetadataURI);
 
-        vinExists[vin] = true;
+        vinHashExists[vinHash] = true;
+        roboshareTokens.setTokenMetadataURI(vehicleId, assetMetadataURI);
+        roboshareTokens.setTokenMetadataURI(revenueTokenId, revenueTokenMetadataURI);
 
         emit AssetRegistered(vehicleId, msg.sender, assetValue, vehicle.assetInfo.status);
-        emit VehicleRegistered(vehicleId, msg.sender, vin);
+        emit VehicleRegistered(vehicleId, msg.sender, vinHash);
     }
 
     // UUPS Upgrade authorization

--- a/protocols/evm/contracts/interfaces/IAssetRegistry.sol
+++ b/protocols/evm/contracts/interfaces/IAssetRegistry.sol
@@ -44,6 +44,8 @@ interface IAssetRegistry {
 
     /**
      * @dev Asset registration and revenue token pool creation.
+     * @param data Registry-specific ABI payload. VehicleRegistry expects
+     *        abi.encode(string vin, string assetMetadataURI, string revenueTokenMetadataURI).
      */
     function registerAsset(bytes calldata data, uint256 assetValue) external returns (uint256 assetId);
 

--- a/protocols/evm/test/base/AssetMetadataBaseTest.t.sol
+++ b/protocols/evm/test/base/AssetMetadataBaseTest.t.sol
@@ -11,15 +11,11 @@ abstract contract AssetMetadataBaseTest is BaseTest {
     uint256 constant TEST_MANUFACTURER_ID = 1;
     string constant TEST_OPTION_CODES = "EX-L,NAV,HSS";
     string constant TEST_METADATA_URI = "ipfs://QmYwAPJzv5CZsnA625b3Xm2fa12p45a8V34vG27s2p45a8";
+    string constant TEST_REVENUE_TOKEN_METADATA_URI = "ipfs://QmRevenueTokenMetadata";
 
     function _setupAssetRegistered() internal virtual override returns (uint256 assetId) {
         vm.prank(partner1);
-        assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
     }
 
     function _setupPrimaryPoolCreated() internal virtual override returns (uint256 revenueTokenId) {
@@ -71,28 +67,8 @@ abstract contract AssetMetadataBaseTest is BaseTest {
         return string(abi.encodePacked(vinPrefixes[prefixIndex], vm.toString(suffix)));
     }
 
-    function _generateVehicleData(uint256 seed)
-        internal
-        pure
-        returns (
-            string memory vin,
-            string memory make,
-            string memory model,
-            uint256 year,
-            uint256 manufacturerId,
-            string memory optionCodes,
-            string memory metadataURI
-        )
-    {
-        string[5] memory makes = ["Toyota", "Honda", "Ford", "BMW", "Tesla"];
-        string[5] memory models = ["Camry", "Civic", "F-150", "X3", "Model 3"];
-
+    function _generateVehicleData(uint256 seed) internal pure returns (string memory vin, string memory metadataURI) {
         vin = _generateVin(seed);
-        make = makes[seed % 5];
-        model = models[(seed + 1) % 5];
-        year = 2020 + (seed % 5);
-        manufacturerId = (seed % 100) + 1;
-        optionCodes = "TEST,OPTION";
         metadataURI = "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb";
     }
 
@@ -101,22 +77,27 @@ abstract contract AssetMetadataBaseTest is BaseTest {
 
         vm.startPrank(partner);
         for (uint256 i = 0; i < count; i++) {
-            (
-                string memory vin,
-                string memory make,
-                string memory model,
-                uint256 year,
-                uint256 manufacturerId,
-                string memory optionCodes,
-                string memory metadataURI
-            ) = _generateVehicleData(i + uint256(keccak256(abi.encodePacked(partner, block.timestamp))));
+            (string memory vin, string memory metadataURI) =
+                _generateVehicleData(i + uint256(keccak256(abi.encodePacked(partner, block.timestamp))));
 
             assetIds[i] = assetRegistry.registerAsset(
-                abi.encode(vin, make, model, year, manufacturerId, optionCodes, metadataURI), ASSET_VALUE
+                _vehicleRegistrationData(vin, metadataURI, TEST_REVENUE_TOKEN_METADATA_URI), ASSET_VALUE
             );
         }
         vm.stopPrank();
 
         return assetIds;
+    }
+
+    function _vehicleRegistrationData(string memory vin) internal pure returns (bytes memory) {
+        return _vehicleRegistrationData(vin, TEST_METADATA_URI, TEST_REVENUE_TOKEN_METADATA_URI);
+    }
+
+    function _vehicleRegistrationData(
+        string memory vin,
+        string memory assetMetadataURI,
+        string memory revenueTokenMetadataURI
+    ) internal pure returns (bytes memory) {
+        return abi.encode(vin, assetMetadataURI, revenueTokenMetadataURI);
     }
 }

--- a/protocols/evm/test/base/TreasuryFlowBaseTest.t.sol
+++ b/protocols/evm/test/base/TreasuryFlowBaseTest.t.sol
@@ -27,12 +27,7 @@ abstract contract TreasuryFlowBaseTest is AssetMetadataBaseTest {
         returns (uint256 assetId, uint256 revenueTokenId, uint256 supply)
     {
         vm.prank(partner);
-        assetId = assetRegistry.registerAsset(
-            abi.encode(
-                vin, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        assetId = assetRegistry.registerAsset(_vehicleRegistrationData(vin), ASSET_VALUE);
 
         supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         uint256 maturityDate = block.timestamp + 365 days;
@@ -50,12 +45,7 @@ abstract contract TreasuryFlowBaseTest is AssetMetadataBaseTest {
     {
         string memory vin = _generateVin(999);
         vm.prank(partner1);
-        assetId = assetRegistry.registerAsset(
-            abi.encode(
-                vin, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        assetId = assetRegistry.registerAsset(_vehicleRegistrationData(vin), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         uint256 maturityDate = block.timestamp + 365 days;

--- a/protocols/evm/test/base/VehicleRegistryBaseTest.t.sol
+++ b/protocols/evm/test/base/VehicleRegistryBaseTest.t.sol
@@ -44,8 +44,8 @@ abstract contract VehicleRegistryBaseTest is AssetMetadataBaseTest {
         _assertAssetState(assetId, expectedOwner, shouldExist);
 
         if (shouldExist && bytes(expectedVin).length > 0) {
-            (string memory vin,,,,,,) = assetRegistry.getVehicleInfo(assetId);
-            assertEq(vin, expectedVin, "Vehicle VIN mismatch");
+            (bytes32 vinHash,,) = assetRegistry.getVehicleInfo(assetId);
+            assertEq(vinHash, keccak256(bytes(expectedVin)), "Vehicle VIN hash mismatch");
         }
     }
 }

--- a/protocols/evm/test/integration/EarningsManager.Integration.t.sol
+++ b/protocols/evm/test/integration/EarningsManager.Integration.t.sol
@@ -498,12 +498,7 @@ contract EarningsManagerIntegrationTest is MarketplaceFlowBaseTest {
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         uint256 maturityDate = block.timestamp + 365 days;

--- a/protocols/evm/test/integration/EarningsManagerPreview.Integration.t.sol
+++ b/protocols/evm/test/integration/EarningsManagerPreview.Integration.t.sol
@@ -71,12 +71,7 @@ contract EarningsManagerPreviewIntegrationTest is MarketplaceFlowBaseTest {
     function testPreviewDistributeEarningsCapsInvestorAmountToRevenueShare() public {
         string memory vin = _generateVin(777);
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                vin, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(vin), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         uint256 maturityDate = block.timestamp + 365 days;

--- a/protocols/evm/test/integration/Marketplace.Integration.t.sol
+++ b/protocols/evm/test/integration/Marketplace.Integration.t.sol
@@ -47,12 +47,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
     ) internal returns (uint256 assetId, uint256 tokenId, uint256 supply) {
         _ensureState(SetupState.InitialAccountsSetup);
         vm.prank(partner1);
-        assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
         tokenId = assetId + 1;
         supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         uint256 maxSupply = maxSupplyOverride == 0 ? supply : maxSupplyOverride;
@@ -428,12 +423,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
     function testCreatePrimaryPoolInvalidMaxSupply() public {
         _ensureState(SetupState.InitialAccountsSetup);
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
         uint256 tokenId = assetId + 1;
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         vm.prank(address(router));

--- a/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
+++ b/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
@@ -245,12 +245,7 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
 
         // Register asset only
         vm.startPrank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         (uint256 revenueTokenId, uint256 tokenSupply) = router.createRevenueTokenPool(
             assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
@@ -592,12 +587,7 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
         vm.stopPrank();
 
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         vm.prank(address(assetRegistry));
         vm.expectRevert();

--- a/protocols/evm/test/integration/Treasury.Integration.t.sol
+++ b/protocols/evm/test/integration/Treasury.Integration.t.sol
@@ -310,12 +310,7 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        scenario.assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        scenario.assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         vm.prank(partner1);
@@ -355,12 +350,7 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        scenario.assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        scenario.assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         vm.prank(partner1);
@@ -543,12 +533,7 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        scenario.assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        scenario.assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         vm.prank(partner1);
@@ -626,12 +611,7 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        scenario.assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        scenario.assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         vm.prank(partner1);
@@ -1502,12 +1482,7 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         uint256 supply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
         uint256 maturityDate = block.timestamp + 365 days;
@@ -1881,12 +1856,7 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         string memory vin = _generateVin(4242);
         uint256 assetValue = 4_400 * 10 ** 6;
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                vin, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            assetValue
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(vin), assetValue);
 
         vm.prank(partner1);
         (uint256 revenueTokenId,) = assetRegistry.createRevenueTokenPool(

--- a/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
+++ b/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
@@ -128,9 +128,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
             usdc,
             partner1,
             buyer,
-            abi.encode(
-                vin, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
+            _vehicleRegistrationData(vin),
             ASSET_VALUE,
             REVENUE_TOKEN_PRICE,
             PRIMARY_PURCHASE_AMOUNT
@@ -149,29 +147,23 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     // Vehicle Registration Tests
 
     function testRegisterAsset() public {
-        (
-            string memory vin,
-            string memory make,
-            string memory model,
-            uint256 year,
-            uint256 manufacturerId,
-            string memory optionCodes,
-            string memory metadataURI
-        ) = _generateVehicleData(1);
+        (string memory vin, string memory metadataURI) = _generateVehicleData(1);
 
         vm.expectEmit(true, true, false, true, address(assetRegistry));
         emit IAssetRegistry.AssetRegistered(1, partner1, ASSET_VALUE, AssetLib.AssetStatus.Pending);
 
         vm.expectEmit(true, true, false, true, address(assetRegistry));
-        emit VehicleRegistry.VehicleRegistered(1, partner1, vin);
+        emit VehicleRegistry.VehicleRegistered(1, partner1, keccak256(bytes(vin)));
 
         vm.prank(partner1);
         uint256 newVehicleId = assetRegistry.registerAsset(
-            abi.encode(vin, make, model, year, manufacturerId, optionCodes, metadataURI), ASSET_VALUE
+            _vehicleRegistrationData(vin, metadataURI, TEST_REVENUE_TOKEN_METADATA_URI), ASSET_VALUE
         );
 
         assertEq(newVehicleId, 1);
         _assertVehicleState(newVehicleId, partner1, vin, true);
+        assertEq(roboshareTokens.uri(newVehicleId), metadataURI);
+        assertEq(roboshareTokens.uri(newVehicleId + 1), TEST_REVENUE_TOKEN_METADATA_URI);
         assertEq(roboshareTokens.getNextTokenId(), 3);
     }
 
@@ -191,9 +183,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     function testRegisterAssetAndCreateRevenueTokenPool() public {
         _ensureState(SetupState.InitialAccountsSetup);
 
-        bytes memory vehicleData = abi.encode(
-            TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-        );
+        bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
 
         vm.prank(partner1);
         (uint256 assetId, uint256 revenueTokenId, uint256 supply) = assetRegistry.registerAssetAndCreateRevenueTokenPool(
@@ -224,12 +214,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         vm.stopPrank();
 
         vm.startPrank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         (uint256 revenueTokenId, uint256 tokenSupply) = assetRegistry.createRevenueTokenPool(
             assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
@@ -245,9 +230,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     function testRegisterAssetAndCreateRevenueTokenPoolUnauthorizedPartner() public {
         _ensureState(SetupState.InitialAccountsSetup);
 
-        bytes memory vehicleData = abi.encode(
-            TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-        );
+        bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
 
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
         vm.prank(unauthorized);
@@ -268,12 +251,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         _ensureState(SetupState.InitialAccountsSetup);
 
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
         vm.prank(unauthorized);
@@ -287,20 +265,25 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     function testUpdateVehicleMetadata() public {
         _ensureState(SetupState.PrimaryPoolCreated);
         // Use a valid IPFS URI (prefix + 46-char CID)
-        string memory newURI = "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb";
+        string memory newAssetURI = "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb";
+        string memory newRevenueTokenURI = "ipfs://QmRevenueTokenMetadataUpdated";
 
         vm.prank(partner1);
-        assetRegistry.updateVehicleMetadata(scenario.assetId, newURI);
+        assetRegistry.updateVehicleMetadata(scenario.assetId, newAssetURI, newRevenueTokenURI);
 
-        (,,,,,, string memory metadataURI) = assetRegistry.getVehicleInfo(scenario.assetId);
-        assertEq(metadataURI, newURI);
+        (, string memory assetMetadataURI, string memory revenueTokenMetadataURI) =
+            assetRegistry.getVehicleInfo(scenario.assetId);
+        assertEq(assetMetadataURI, newAssetURI);
+        assertEq(revenueTokenMetadataURI, newRevenueTokenURI);
+        assertEq(roboshareTokens.uri(scenario.assetId), newAssetURI);
+        assertEq(roboshareTokens.uri(scenario.revenueTokenId), newRevenueTokenURI);
     }
 
     function testUpdateVehicleMetadataInvalidUri() public {
         _ensureState(SetupState.PrimaryPoolCreated);
         vm.expectRevert(VehicleLib.InvalidMetadataURI.selector);
         vm.prank(partner1);
-        assetRegistry.updateVehicleMetadata(scenario.assetId, "http://not-ipfs");
+        assetRegistry.updateVehicleMetadata(scenario.assetId, "http://not-ipfs", "ipfs://QmRevenueTokenMetadataUpdated");
     }
 
     // Access Control Tests
@@ -308,45 +291,49 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     function testRegisterAssetUnauthorizedPartner() public {
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
         vm.prank(unauthorized);
-        assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
     }
 
     function testUpdateVehicleMetadataUnauthorizedPartner() public {
         _ensureState(SetupState.PrimaryPoolCreated);
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
         vm.prank(unauthorized);
-        assetRegistry.updateVehicleMetadata(scenario.assetId, "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb");
+        assetRegistry.updateVehicleMetadata(
+            scenario.assetId,
+            "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb",
+            "ipfs://QmRevenueTokenMetadataUpdated"
+        );
+    }
+
+    function testUpdateVehicleMetadataAuthorizedPartnerNotAssetOwner() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+        vm.expectRevert(IAssetRegistry.NotAssetOwner.selector);
+        vm.prank(partner2);
+        assetRegistry.updateVehicleMetadata(
+            scenario.assetId,
+            "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb",
+            "ipfs://QmRevenueTokenMetadataUpdated"
+        );
     }
 
     // Error Cases
 
     function testRegisterAssetDuplicateVIN() public {
         _ensureState(SetupState.PrimaryPoolCreated);
-        (
-            ,
-            string memory make,
-            string memory model,
-            uint256 year,
-            uint256 manufacturerId,
-            string memory optionCodes,
-            string memory metadataURI
-        ) = _generateVehicleData(3);
+        (, string memory metadataURI) = _generateVehicleData(3);
         vm.expectRevert(VehicleRegistry.VehicleAlreadyExists.selector);
         vm.prank(partner2);
         assetRegistry.registerAsset(
-            abi.encode(TEST_VIN, make, model, year, manufacturerId, optionCodes, metadataURI), ASSET_VALUE
+            _vehicleRegistrationData(TEST_VIN, metadataURI, TEST_REVENUE_TOKEN_METADATA_URI), ASSET_VALUE
         );
     }
 
     function testUpdateVehicleMetadataVehicleDoesNotExist() public {
         vm.expectRevert(VehicleRegistry.VehicleDoesNotExist.selector);
         vm.prank(partner1);
-        assetRegistry.updateVehicleMetadata(999, "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb");
+        assetRegistry.updateVehicleMetadata(
+            999, "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb", "ipfs://QmRevenueTokenMetadataUpdated"
+        );
     }
 
     function testPreviewMintRevenueTokensAssetNotFound() public {
@@ -389,9 +376,9 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     }
 
     function testVINExists() public {
-        assertFalse(assetRegistry.vinExists("FAKE_VIN"));
+        assertFalse(assetRegistry.vinHashExists(keccak256(bytes("FAKE_VIN"))));
         _ensureState(SetupState.PrimaryPoolCreated);
-        assertTrue(assetRegistry.vinExists(TEST_VIN));
+        assertTrue(assetRegistry.vinHashExists(keccak256(bytes(TEST_VIN))));
     }
 
     // New: registry introspection and asset info branches
@@ -432,9 +419,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
 
         uint256 maturityDate = block.timestamp + 365 days;
 
-        bytes memory vehicleData = abi.encode(
-            TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-        );
+        bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
 
         (uint256 assetId, uint256 revenueTokenId, uint256 actualSupply) = assetRegistry.registerAssetAndCreateRevenueTokenPool(
             vehicleData, assetValue, tokenPrice, maturityDate, 10_000, 1_000, 0, false, false
@@ -468,9 +453,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
 
         vm.startPrank(partner1);
 
-        bytes memory vehicleData = abi.encode(
-            TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-        );
+        bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
 
         (, uint256 revenueTokenId, uint256 tokenSupply) = assetRegistry.registerAssetAndCreateRevenueTokenPool(
             vehicleData, assetValue, tokenPrice, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
@@ -491,12 +474,15 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
 
         assertTrue(assetRegistry.assetExists(scenario.assetId));
 
-        string memory newURI = "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb";
+        string memory newAssetURI = "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb";
+        string memory newRevenueTokenURI = "ipfs://QmRevenueTokenMetadataUpdated";
         vm.prank(partner1);
-        assetRegistry.updateVehicleMetadata(scenario.assetId, newURI);
+        assetRegistry.updateVehicleMetadata(scenario.assetId, newAssetURI, newRevenueTokenURI);
 
-        (,,,,,, string memory metadataURI) = assetRegistry.getVehicleInfo(scenario.assetId);
-        assertEq(metadataURI, newURI);
+        (, string memory assetMetadataURI, string memory revenueTokenMetadataURI) =
+            assetRegistry.getVehicleInfo(scenario.assetId);
+        assertEq(assetMetadataURI, newAssetURI);
+        assertEq(revenueTokenMetadataURI, newRevenueTokenURI);
     }
 
     function testSetAssetStatus() public {

--- a/protocols/evm/test/unit/Libraries.t.sol
+++ b/protocols/evm/test/unit/Libraries.t.sol
@@ -76,31 +76,16 @@ contract VehicleHelper {
 
     VehicleLib.VehicleInfo internal info;
 
-    function init(
-        string memory vin,
-        string memory make,
-        string memory model,
-        uint256 year,
-        uint256 manufacturerId,
-        string memory optionCodes,
-        string memory metadataUri
-    ) external {
-        info.initializeVehicleInfo(vin, make, model, year, manufacturerId, optionCodes, metadataUri);
+    function init(string memory vin, string memory assetMetadataURI, string memory revenueTokenMetadataURI) external {
+        info.initializeVehicleInfo(VehicleLib.toVINHash(vin), assetMetadataURI, revenueTokenMetadataURI);
     }
 
-    // Intentional raw-state injection for VehicleLib malformed-input tests only.
-    function setRaw(string memory make, string memory model, uint256 year) external {
-        info.make = make;
-        info.model = model;
-        info.year = year;
-    }
-
-    function displayName() external view returns (string memory) {
-        return info.getDisplayName();
+    function vinHash() external view returns (bytes32) {
+        return info.vinHash;
     }
 
     function updateMeta(string memory uri) external {
-        info.updateDynamicMetadata(uri);
+        info.updateMetadata(uri, uri);
     }
 }
 
@@ -689,14 +674,16 @@ contract LibrariesTest is Test {
         assertEq(cteh.salesPenalty(alice, 0), 0);
     }
 
-    function testVehicleDisplayNameZeroYear() public {
-        vh.setRaw("Honda", "Civic", 0);
-        assertEq(vh.displayName(), "Honda Civic 0");
+    function testVehicleVinHash() public {
+        vh.init(
+            "1HGCM82633A123456", "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb", "ipfs://QmRevenueTokenMetadata"
+        );
+        assertEq(vh.vinHash(), keccak256(bytes("1HGCM82633A123456")));
     }
 
     function testVehicleInvalidMetadataUri() public {
         vm.expectRevert(VehicleLib.InvalidMetadataURI.selector);
-        vh.init("1HGCM82633A123456", "Honda", "Civic", 2020, 1, "EX-L", "http://bad-uri");
+        vh.init("1HGCM82633A123456", "http://bad-uri", "ipfs://QmRevenueTokenMetadata");
     }
 
     function testTokenUnclaimedForPositionsAndEarningsHelpers() public {

--- a/protocols/evm/test/unit/RegistryRouter.t.sol
+++ b/protocols/evm/test/unit/RegistryRouter.t.sol
@@ -193,12 +193,7 @@ contract RegistryRouterTest is AssetMetadataBaseTest {
     function testRoutingGetAssetInfo() public {
         // Register asset via VehicleRegistry (which calls router)
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         // Call via Router
         AssetLib.AssetInfo memory info = router.getAssetInfo(assetId);
@@ -207,12 +202,7 @@ contract RegistryRouterTest is AssetMetadataBaseTest {
 
     function testRoutingAssetExists() public {
         vm.prank(partner1);
-        uint256 assetId = assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
+        uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
 
         assertTrue(router.assetExists(assetId));
         assertFalse(router.assetExists(999));

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -155,6 +155,27 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         assertEq(roboshareTokens.uri(1), newURI);
     }
 
+    function testSetTokenMetadataURI() public {
+        string memory tokenMetadata = "ipfs://QmTokenMetadata";
+
+        vm.prank(admin);
+        roboshareTokens.setTokenMetadataURI(1, tokenMetadata);
+
+        assertEq(roboshareTokens.uri(1), tokenMetadata);
+    }
+
+    function testSetTokenMetadataURIUnauthorizedCaller() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                unauthorized,
+                roboshareTokens.URI_SETTER_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        roboshareTokens.setTokenMetadataURI(1, "ipfs://QmTokenMetadata");
+    }
+
     function testTransfers() public {
         // Setup: mint tokens to user1
         uint256 tokenId = 101;

--- a/protocols/evm/test/unit/VehicleRegistry.t.sol
+++ b/protocols/evm/test/unit/VehicleRegistry.t.sol
@@ -102,65 +102,29 @@ contract VehicleRegistryTest is VehicleRegistryBaseTest {
         assetRegistry.getVehicleInfo(999);
     }
 
-    function testGetVehicleDisplayNameVehicleDoesNotExist() public {
-        vm.expectRevert(VehicleRegistry.VehicleDoesNotExist.selector);
-        assetRegistry.getVehicleDisplayName(999);
-    }
-
     function testRegisterVehicleInvalidVINLength() public {
         _ensureState(SetupState.InitialAccountsSetup);
         string memory shortVin = "VIN123"; // <10 length
         vm.expectRevert(VehicleLib.InvalidVINLength.selector);
         vm.prank(partner1);
+        assetRegistry.registerAsset(_vehicleRegistrationData(shortVin), ASSET_VALUE);
+    }
+
+    function testRegisterVehicleInvalidMetadataURI() public {
+        _ensureState(SetupState.InitialAccountsSetup);
+        vm.expectRevert(VehicleLib.InvalidMetadataURI.selector);
+        vm.prank(partner1);
         assetRegistry.registerAsset(
-            abi.encode(
-                shortVin, TEST_MAKE, TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
+            _vehicleRegistrationData(TEST_VIN, "http://invalid-uri", TEST_REVENUE_TOKEN_METADATA_URI), ASSET_VALUE
         );
     }
 
-    function testRegisterVehicleEmptyMake() public {
+    function testRegisterVehicleInvalidRevenueTokenMetadataURI() public {
         _ensureState(SetupState.InitialAccountsSetup);
-        vm.expectRevert(VehicleLib.InvalidMake.selector);
+        vm.expectRevert(VehicleLib.InvalidMetadataURI.selector);
         vm.prank(partner1);
         assetRegistry.registerAsset(
-            abi.encode(TEST_VIN, "", TEST_MODEL, TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI),
-            ASSET_VALUE
-        );
-    }
-
-    function testRegisterVehicleEmptyModel() public {
-        _ensureState(SetupState.InitialAccountsSetup);
-        vm.expectRevert(VehicleLib.InvalidModel.selector);
-        vm.prank(partner1);
-        assetRegistry.registerAsset(
-            abi.encode(TEST_VIN, TEST_MAKE, "", TEST_YEAR, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI),
-            ASSET_VALUE
-        );
-    }
-
-    function testRegisterVehicleInvalidYearTooLow() public {
-        _ensureState(SetupState.InitialAccountsSetup);
-        vm.expectRevert(VehicleLib.InvalidYear.selector);
-        vm.prank(partner1);
-        assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, 1980, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
-        );
-    }
-
-    function testRegisterVehicleInvalidYearTooHigh() public {
-        _ensureState(SetupState.InitialAccountsSetup);
-        vm.expectRevert(VehicleLib.InvalidYear.selector);
-        vm.prank(partner1);
-        assetRegistry.registerAsset(
-            abi.encode(
-                TEST_VIN, TEST_MAKE, TEST_MODEL, 2040, TEST_MANUFACTURER_ID, TEST_OPTION_CODES, TEST_METADATA_URI
-            ),
-            ASSET_VALUE
+            _vehicleRegistrationData(TEST_VIN, TEST_METADATA_URI, "http://invalid-uri"), ASSET_VALUE
         );
     }
 
@@ -177,23 +141,12 @@ contract VehicleRegistryTest is VehicleRegistryBaseTest {
     function testGetVehicleInfo() public {
         _ensureState(SetupState.AssetRegistered);
 
-        (
-            string memory vin,
-            string memory make,
-            string memory model,
-            uint256 year,
-            uint256 manufacturerId,
-            string memory optionCodes,
-            string memory metadataUri
-        ) = assetRegistry.getVehicleInfo(scenario.assetId);
+        (bytes32 vinHash, string memory assetMetadataURI, string memory revenueTokenMetadataURI) =
+            assetRegistry.getVehicleInfo(scenario.assetId);
 
-        assertEq(vin, TEST_VIN);
-        assertEq(make, TEST_MAKE);
-        assertEq(model, TEST_MODEL);
-        assertEq(year, TEST_YEAR);
-        assertEq(manufacturerId, TEST_MANUFACTURER_ID);
-        assertEq(optionCodes, TEST_OPTION_CODES);
-        assertEq(metadataUri, TEST_METADATA_URI);
+        assertEq(vinHash, keccak256(bytes(TEST_VIN)));
+        assertEq(assetMetadataURI, TEST_METADATA_URI);
+        assertEq(revenueTokenMetadataURI, TEST_REVENUE_TOKEN_METADATA_URI);
     }
 
     // ============ Admin Function Tests ============


### PR DESCRIPTION
## Summary

- Slims `VehicleRegistry` vehicle metadata state to protocol anchors plus separate asset NFT and revenue-token URI pointers.
- Adds per-token metadata URI support in `RoboshareTokens` and wires registration/update flows to distinct asset and revenue token metadata documents.
- Restricts vehicle metadata updates to the authorized partner that owns the asset NFT.
- Documents the ROB-96 metadata boundary, including `assetValue` as transitional legacy state and ROB-84/ROB-85 as web/subgraph follow-ups.

## Validation

- `yarn evm:compile`
- `forge test --offline --match-path test/unit/VehicleRegistry.t.sol`
- `forge test --offline --match-path test/integration/VehicleRegistry.Integration.t.sol`
- `forge test --offline --match-path test/unit/RoboshareTokens.t.sol`
- `forge test --offline --match-path test/unit/Libraries.t.sol`
- `git diff --check`