### PR TITLE
feat(evm): implement manager FIFO position reads (ROB-71)

### DIFF
--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { TokenLib } from "./Libraries.sol";
 import { IPositionManager } from "./interfaces/IPositionManager.sol";
 
 /**
@@ -24,6 +25,8 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     address public marketplace;
     address public treasury;
     address public usdc;
+
+    mapping(uint256 => TokenLib.TokenInfo) private _revenueTokenInfos;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -148,6 +151,25 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     }
 
     function recordPositionMutation(PositionMutation calldata mutation) external onlyRole(AUTHORIZED_MARKETPLACE_ROLE) {
+        if (!TokenLib.isRevenueToken(mutation.tokenId)) {
+            revert NotRevenueToken();
+        }
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[mutation.tokenId];
+        if (tokenInfo.tokenId == 0) {
+            tokenInfo.tokenId = mutation.tokenId;
+        }
+
+        if (mutation.mutationType == PositionMutationType.Mint) {
+            tokenInfo.tokenSupply += mutation.amount;
+            TokenLib.addPosition(tokenInfo, mutation.account, mutation.amount);
+        } else if (mutation.mutationType == PositionMutationType.Burn) {
+            tokenInfo.tokenSupply -= mutation.amount;
+            TokenLib.removePosition(tokenInfo, mutation.account, mutation.amount);
+        } else {
+            revert UnsupportedPositionMutation(mutation.mutationType);
+        }
+
         emit PositionMutated(
             mutation.assetId,
             mutation.tokenId,
@@ -157,6 +179,24 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
             mutation.mutationType,
             mutation.reason
         );
+    }
+
+    function getUserPositions(uint256 revenueTokenId, address holder)
+        external
+        view
+        returns (TokenLib.TokenPosition[] memory positions)
+    {
+        if (!TokenLib.isRevenueToken(revenueTokenId)) {
+            revert NotRevenueToken();
+        }
+
+        TokenLib.PositionQueue storage queue = _revenueTokenInfos[revenueTokenId].positions[holder];
+        uint256 size = queue.tail - queue.head;
+        positions = new TokenLib.TokenPosition[](size);
+
+        for (uint256 i = 0; i < size; i++) {
+            positions[i] = queue.items[queue.head + i];
+        }
     }
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import { TokenLib } from "../Libraries.sol";
+
 /**
  * @title IPositionManager
  * @notice Canonical manager boundary for position, lock, redemption, and settlement state.
@@ -87,6 +89,8 @@ interface IPositionManager {
     );
 
     error ZeroAddress();
+    error NotRevenueToken();
+    error UnsupportedPositionMutation(PositionMutationType mutationType);
 
     function initialize(
         address admin,
@@ -119,6 +123,11 @@ interface IPositionManager {
     function updateUsdc(address newUsdc) external;
 
     function recordPositionMutation(PositionMutation calldata mutation) external;
+
+    function getUserPositions(uint256 revenueTokenId, address holder)
+        external
+        view
+        returns (TokenLib.TokenPosition[] memory positions);
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
         external;

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { Test } from "forge-std/Test.sol";
+import { TokenLib } from "../../contracts/Libraries.sol";
 import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 import { PositionManager } from "../../contracts/PositionManager.sol";
 
@@ -18,6 +19,11 @@ contract PositionManagerTest is Test {
     address public treasury = makeAddr("treasury");
     address public usdc = makeAddr("usdc");
     address public unauthorized = makeAddr("unauthorized");
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+
+    uint256 private constant ASSET_ID = 101;
+    uint256 private constant TOKEN_ID = 102;
 
     bytes32 private constant PRIMARY_REASON = keccak256("primary");
     bytes32 private constant LISTING_REASON = keccak256("listing");
@@ -157,9 +163,9 @@ contract PositionManagerTest is Test {
 
     function testAuthorizedMarketplaceCanRecordPositionMutation() public {
         IPositionManager.PositionMutation memory mutation = IPositionManager.PositionMutation({
-            assetId: 1,
-            tokenId: 2,
-            account: makeAddr("holder"),
+            assetId: ASSET_ID,
+            tokenId: TOKEN_ID,
+            account: alice,
             amount: 3,
             auxValue: 4,
             mutationType: IPositionManager.PositionMutationType.Mint,
@@ -181,11 +187,117 @@ contract PositionManagerTest is Test {
         positionManager.recordPositionMutation(mutation);
     }
 
+    function testAuthorizedMarketplaceMintMutationStoresPosition() public {
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 100,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+
+        TokenLib.TokenPosition[] memory positions = positionManager.getUserPositions(TOKEN_ID, alice);
+        assertEq(positions.length, 1);
+        assertEq(positions[0].uid, 0);
+        assertEq(positions[0].tokenId, TOKEN_ID);
+        assertEq(positions[0].amount, 100);
+        assertGt(positions[0].acquiredAt, 0);
+        assertEq(positions[0].soldAt, 0);
+        assertEq(positions[0].redemptionEpoch, 0);
+    }
+
+    function testBurnConsumesPositionsFifo() public {
+        vm.startPrank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 100,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+        vm.warp(block.timestamp + 1);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 50,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+        vm.warp(block.timestamp + 1);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 120,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Burn,
+                reason: REDEEM_REASON
+            })
+        );
+        vm.stopPrank();
+
+        TokenLib.TokenPosition[] memory positions = positionManager.getUserPositions(TOKEN_ID, alice);
+        assertEq(positions.length, 2);
+        assertEq(positions[0].amount, 0);
+        assertTrue(positions[0].soldAt > 0);
+        assertEq(positions[1].amount, 30);
+    }
+
+    function testNonRevenueTokenPositionMutationReverts() public {
+        vm.expectRevert(IPositionManager.NotRevenueToken.selector);
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: ASSET_ID,
+                account: alice,
+                amount: 1,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+    }
+
+    function testTransferMutationsRevertUntilHookShapeIsImplemented() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPositionManager.UnsupportedPositionMutation.selector, IPositionManager.PositionMutationType.TransferOut
+            )
+        );
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 1,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.TransferOut,
+                reason: LISTING_REASON
+            })
+        );
+    }
+
     function testUnauthorizedCallerCannotRecordPositionMutation() public {
         IPositionManager.PositionMutation memory mutation = IPositionManager.PositionMutation({
-            assetId: 1,
-            tokenId: 2,
-            account: makeAddr("holder"),
+            assetId: ASSET_ID,
+            tokenId: TOKEN_ID,
+            account: alice,
             amount: 3,
             auxValue: 4,
             mutationType: IPositionManager.PositionMutationType.Mint,
@@ -205,26 +317,26 @@ contract PositionManagerTest is Test {
 
     function testAuthorizedRouterCanRecordPositionLock() public {
         vm.expectEmit(true, true, true, true, address(positionManager));
-        emit PositionLockUpdated(1, 2, makeAddr("holder"), block.timestamp + 1 days, LISTING_REASON);
+        emit PositionLockUpdated(ASSET_ID, TOKEN_ID, alice, block.timestamp + 1 days, LISTING_REASON);
 
         vm.prank(registryRouter);
-        positionManager.recordPositionLock(1, 2, makeAddr("holder"), block.timestamp + 1 days, LISTING_REASON);
+        positionManager.recordPositionLock(ASSET_ID, TOKEN_ID, alice, block.timestamp + 1 days, LISTING_REASON);
     }
 
     function testAuthorizedTreasuryCanRecordRedemptionAndSettlementEvents() public {
         vm.startPrank(treasury);
 
         vm.expectEmit(true, true, false, true, address(positionManager));
-        emit RedemptionEpochUpdated(2, 1, 100, REDEEM_REASON);
-        positionManager.recordRedemptionEpoch(2, 1, 100, REDEEM_REASON);
+        emit RedemptionEpochUpdated(TOKEN_ID, 1, 100, REDEEM_REASON);
+        positionManager.recordRedemptionEpoch(TOKEN_ID, 1, 100, REDEEM_REASON);
 
         vm.expectEmit(true, true, false, true, address(positionManager));
-        emit SettlementConfigured(1, 1, 1000, 10, SETTLE_REASON);
-        positionManager.recordSettlement(1, 1, 1000, 10, SETTLE_REASON);
+        emit SettlementConfigured(ASSET_ID, 1, 1000, 10, SETTLE_REASON);
+        positionManager.recordSettlement(ASSET_ID, 1, 1000, 10, SETTLE_REASON);
 
         vm.expectEmit(true, true, true, true, address(positionManager));
-        emit SettlementClaimRecorded(1, 2, makeAddr("holder"), 20, 200, CLAIM_REASON);
-        positionManager.recordSettlementClaim(1, 2, makeAddr("holder"), 20, 200, CLAIM_REASON);
+        emit SettlementClaimRecorded(ASSET_ID, TOKEN_ID, alice, 20, 200, CLAIM_REASON);
+        positionManager.recordSettlementClaim(ASSET_ID, TOKEN_ID, alice, 20, 200, CLAIM_REASON);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
## Summary

- Move FIFO revenue-token position storage into `PositionManager` and back it with manager-owned `TokenLib.TokenInfo` state.
- Add the holder-facing `getUserPositions(...)` manager read needed for downstream earnings rewiring.
- Keep `ROB-71` scoped to mint/burn FIFO bookkeeping and fail fast on transfer mutations until the token hook and tranche semantics are implemented in later issues.
- Cover the manager-scoped behavior with focused tests for mint storage, FIFO burn consumption, unsupported transfer mutations, and non-revenue-token reverts.

## Validation

- `yarn evm:compile`
- `forge test --offline --match-path test/unit/PositionManager.t.sol`
- `git diff --check`

Note: `yarn evm:compile` succeeded with a sandbox-only Foundry warning about writing `~/.foundry/cache/signatures`.
