### PR TITLE
feat(evm): add manager listing locks and sale-penalty bookkeeping (ROB-72)

### DIFF
--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import { TokenLib } from "./Libraries.sol";
 import { IPositionManager } from "./interfaces/IPositionManager.sol";
 
@@ -218,7 +219,7 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         return totalBalance - lockedAmount;
     }
 
-    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount, uint256 totalBalance)
+    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount)
         external
         onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
     {
@@ -226,6 +227,7 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         if (amount == 0) revert InvalidAmount();
 
         uint256 lockedAmount = _lockedAmounts[holder][revenueTokenId];
+        uint256 totalBalance = IERC1155(roboshareTokens).balanceOf(holder, revenueTokenId);
         if (totalBalance < lockedAmount + amount) revert InsufficientUnlockedBalance();
 
         _lockedAmounts[holder][revenueTokenId] = lockedAmount + amount;

--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -27,6 +27,8 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     address public usdc;
 
     mapping(uint256 => TokenLib.TokenInfo) private _revenueTokenInfos;
+    mapping(address => mapping(uint256 => uint256)) private _lockedAmounts;
+    mapping(uint256 => uint256) private _listingSalePenalties;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -186,9 +188,7 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         view
         returns (TokenLib.TokenPosition[] memory positions)
     {
-        if (!TokenLib.isRevenueToken(revenueTokenId)) {
-            revert NotRevenueToken();
-        }
+        _requireRevenueToken(revenueTokenId);
 
         TokenLib.PositionQueue storage queue = _revenueTokenInfos[revenueTokenId].positions[holder];
         uint256 size = queue.tail - queue.head;
@@ -197,6 +197,86 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         for (uint256 i = 0; i < size; i++) {
             positions[i] = queue.items[queue.head + i];
         }
+    }
+
+    function getLockedAmount(address holder, uint256 revenueTokenId) external view returns (uint256) {
+        _requireRevenueToken(revenueTokenId);
+        return _lockedAmounts[holder][revenueTokenId];
+    }
+
+    function getAvailableAmount(address holder, uint256 revenueTokenId, uint256 totalBalance)
+        external
+        view
+        returns (uint256)
+    {
+        _requireRevenueToken(revenueTokenId);
+
+        uint256 lockedAmount = _lockedAmounts[holder][revenueTokenId];
+        if (lockedAmount >= totalBalance) {
+            return 0;
+        }
+        return totalBalance - lockedAmount;
+    }
+
+    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount, uint256 totalBalance)
+        external
+        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
+    {
+        _requireRevenueToken(revenueTokenId);
+        if (amount == 0) revert InvalidAmount();
+
+        uint256 lockedAmount = _lockedAmounts[holder][revenueTokenId];
+        if (totalBalance < lockedAmount + amount) revert InsufficientUnlockedBalance();
+
+        _lockedAmounts[holder][revenueTokenId] = lockedAmount + amount;
+        emit ListingLocked(holder, revenueTokenId, amount);
+    }
+
+    function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount)
+        external
+        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
+    {
+        _requireRevenueToken(revenueTokenId);
+        if (amount == 0) revert InvalidAmount();
+
+        uint256 lockedAmount = _lockedAmounts[holder][revenueTokenId];
+        if (lockedAmount < amount) revert InsufficientLockedBalance();
+
+        _lockedAmounts[holder][revenueTokenId] = lockedAmount - amount;
+        emit ListingUnlocked(holder, revenueTokenId, amount);
+    }
+
+    function settleLockedTransfer(address from, address to, uint256 revenueTokenId, uint256 amount)
+        external
+        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
+    {
+        _requireRevenueToken(revenueTokenId);
+        if (amount == 0) revert InvalidAmount();
+
+        uint256 lockedAmount = _lockedAmounts[from][revenueTokenId];
+        if (lockedAmount < amount) revert InsufficientLockedBalance();
+
+        _lockedAmounts[from][revenueTokenId] = lockedAmount - amount;
+        emit ListingUnlocked(from, revenueTokenId, amount);
+        emit LockedTransferSettled(from, to, revenueTokenId, amount);
+    }
+
+    function bookSalePenalty(uint256 listingId, address seller, uint256 revenueTokenId, uint256 amount)
+        external
+        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
+    {
+        _requireRevenueToken(revenueTokenId);
+
+        _listingSalePenalties[listingId] = amount;
+        emit SalePenaltyBooked(listingId, seller, revenueTokenId, amount);
+    }
+
+    function clearSalePenalty(uint256 listingId) external onlyRole(AUTHORIZED_MARKETPLACE_ROLE) {
+        delete _listingSalePenalties[listingId];
+    }
+
+    function getSalePenalty(uint256 listingId) external view returns (uint256) {
+        return _listingSalePenalties[listingId];
     }
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
@@ -235,4 +315,10 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
+
+    function _requireRevenueToken(uint256 revenueTokenId) internal pure {
+        if (!TokenLib.isRevenueToken(revenueTokenId)) {
+            revert NotRevenueToken();
+        }
+    }
 }

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -148,7 +148,7 @@ interface IPositionManager {
         view
         returns (uint256);
 
-    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount, uint256 totalBalance) external;
+    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount) external;
 
     function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount) external;
 

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -63,6 +63,15 @@ interface IPositionManager {
         bytes32 reason
     );
 
+    event ListingLocked(address indexed holder, uint256 indexed revenueTokenId, uint256 amount);
+    event ListingUnlocked(address indexed holder, uint256 indexed revenueTokenId, uint256 amount);
+    event LockedTransferSettled(
+        address indexed from, address indexed to, uint256 indexed revenueTokenId, uint256 amount
+    );
+    event SalePenaltyBooked(
+        uint256 indexed listingId, address indexed seller, uint256 indexed revenueTokenId, uint256 amount
+    );
+
     event PositionLockUpdated(
         uint256 indexed assetId, uint256 indexed tokenId, address indexed account, uint256 lockUntil, bytes32 reason
     );
@@ -90,6 +99,9 @@ interface IPositionManager {
 
     error ZeroAddress();
     error NotRevenueToken();
+    error InvalidAmount();
+    error InsufficientUnlockedBalance();
+    error InsufficientLockedBalance();
     error UnsupportedPositionMutation(PositionMutationType mutationType);
 
     function initialize(
@@ -128,6 +140,25 @@ interface IPositionManager {
         external
         view
         returns (TokenLib.TokenPosition[] memory positions);
+
+    function getLockedAmount(address holder, uint256 revenueTokenId) external view returns (uint256);
+
+    function getAvailableAmount(address holder, uint256 revenueTokenId, uint256 totalBalance)
+        external
+        view
+        returns (uint256);
+
+    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount, uint256 totalBalance) external;
+
+    function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount) external;
+
+    function settleLockedTransfer(address from, address to, uint256 revenueTokenId, uint256 amount) external;
+
+    function bookSalePenalty(uint256 listingId, address seller, uint256 revenueTokenId, uint256 amount) external;
+
+    function clearSalePenalty(uint256 listingId) external;
+
+    function getSalePenalty(uint256 listingId) external view returns (uint256);
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
         external;

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -41,6 +41,15 @@ contract PositionManagerTest is Test {
         bytes32 reason
     );
 
+    event ListingLocked(address indexed holder, uint256 indexed revenueTokenId, uint256 amount);
+    event ListingUnlocked(address indexed holder, uint256 indexed revenueTokenId, uint256 amount);
+    event LockedTransferSettled(
+        address indexed from, address indexed to, uint256 indexed revenueTokenId, uint256 amount
+    );
+    event SalePenaltyBooked(
+        uint256 indexed listingId, address indexed seller, uint256 indexed revenueTokenId, uint256 amount
+    );
+
     event PositionLockUpdated(
         uint256 indexed assetId, uint256 indexed tokenId, address indexed account, uint256 lockUntil, bytes32 reason
     );
@@ -257,6 +266,76 @@ contract PositionManagerTest is Test {
         assertEq(positions[1].amount, 30);
     }
 
+    function testGetLockedAmountRevertsForNonRevenueToken() public {
+        vm.expectRevert(IPositionManager.NotRevenueToken.selector);
+        positionManager.getLockedAmount(alice, ASSET_ID);
+    }
+
+    function testLockForListingTracksAmount() public {
+        vm.expectEmit(true, true, false, true, address(positionManager));
+        emit ListingLocked(alice, TOKEN_ID, 40);
+
+        vm.prank(marketplace);
+        positionManager.lockForListing(alice, TOKEN_ID, 40, 100);
+
+        assertEq(positionManager.getLockedAmount(alice, TOKEN_ID), 40);
+        assertEq(positionManager.getAvailableAmount(alice, TOKEN_ID, 100), 60);
+    }
+
+    function testLockForListingRevertsWhenUnlockedBalanceInsufficient() public {
+        vm.startPrank(marketplace);
+        positionManager.lockForListing(alice, TOKEN_ID, 80, 100);
+
+        vm.expectRevert(IPositionManager.InsufficientUnlockedBalance.selector);
+        positionManager.lockForListing(alice, TOKEN_ID, 21, 100);
+        vm.stopPrank();
+    }
+
+    function testUnlockForListingRevertsWhenLockedBalanceInsufficient() public {
+        vm.expectRevert(IPositionManager.InsufficientLockedBalance.selector);
+        vm.prank(marketplace);
+        positionManager.unlockForListing(alice, TOKEN_ID, 1);
+    }
+
+    function testSettleLockedTransferConsumesLockBeforeTokenMove() public {
+        vm.prank(marketplace);
+        positionManager.lockForListing(alice, TOKEN_ID, 55, 100);
+
+        vm.expectEmit(true, true, false, true, address(positionManager));
+        emit ListingUnlocked(alice, TOKEN_ID, 20);
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit LockedTransferSettled(alice, bob, TOKEN_ID, 20);
+
+        vm.prank(marketplace);
+        positionManager.settleLockedTransfer(alice, bob, TOKEN_ID, 20);
+
+        assertEq(positionManager.getLockedAmount(alice, TOKEN_ID), 35);
+    }
+
+    function testSettleLockedTransferRevertsForInvalidMove() public {
+        vm.prank(marketplace);
+        positionManager.lockForListing(alice, TOKEN_ID, 10, 100);
+
+        vm.expectRevert(IPositionManager.InsufficientLockedBalance.selector);
+        vm.prank(marketplace);
+        positionManager.settleLockedTransfer(alice, bob, TOKEN_ID, 11);
+    }
+
+    function testSalesPenaltyBookkeeping() public {
+        uint256 listingId = 7;
+
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit SalePenaltyBooked(listingId, alice, TOKEN_ID, 15e6);
+
+        vm.prank(marketplace);
+        positionManager.bookSalePenalty(listingId, alice, TOKEN_ID, 15e6);
+        assertEq(positionManager.getSalePenalty(listingId), 15e6);
+
+        vm.prank(marketplace);
+        positionManager.clearSalePenalty(listingId);
+        assertEq(positionManager.getSalePenalty(listingId), 0);
+    }
+
     function testNonRevenueTokenPositionMutationReverts() public {
         vm.expectRevert(IPositionManager.NotRevenueToken.selector);
         vm.prank(marketplace);
@@ -313,6 +392,18 @@ contract PositionManagerTest is Test {
         );
         vm.prank(unauthorized);
         positionManager.recordPositionMutation(mutation);
+    }
+
+    function testUnauthorizedCallerCannotLockForListing() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                unauthorized,
+                positionManager.AUTHORIZED_MARKETPLACE_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        positionManager.lockForListing(alice, TOKEN_ID, 1, 1);
     }
 
     function testAuthorizedRouterCanRecordPositionLock() public {

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import { Test } from "forge-std/Test.sol";
 import { TokenLib } from "../../contracts/Libraries.sol";
 import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
@@ -272,23 +273,35 @@ contract PositionManagerTest is Test {
     }
 
     function testLockForListingTracksAmount() public {
+        _mockRevenueTokenBalance(alice, TOKEN_ID, 100);
+
         vm.expectEmit(true, true, false, true, address(positionManager));
         emit ListingLocked(alice, TOKEN_ID, 40);
 
         vm.prank(marketplace);
-        positionManager.lockForListing(alice, TOKEN_ID, 40, 100);
+        positionManager.lockForListing(alice, TOKEN_ID, 40);
 
         assertEq(positionManager.getLockedAmount(alice, TOKEN_ID), 40);
         assertEq(positionManager.getAvailableAmount(alice, TOKEN_ID, 100), 60);
     }
 
     function testLockForListingRevertsWhenUnlockedBalanceInsufficient() public {
+        _mockRevenueTokenBalance(alice, TOKEN_ID, 100);
+
         vm.startPrank(marketplace);
-        positionManager.lockForListing(alice, TOKEN_ID, 80, 100);
+        positionManager.lockForListing(alice, TOKEN_ID, 80);
 
         vm.expectRevert(IPositionManager.InsufficientUnlockedBalance.selector);
-        positionManager.lockForListing(alice, TOKEN_ID, 21, 100);
+        positionManager.lockForListing(alice, TOKEN_ID, 21);
         vm.stopPrank();
+    }
+
+    function testLockForListingChecksRoboshareTokenBalance() public {
+        _mockRevenueTokenBalance(alice, TOKEN_ID, 39);
+
+        vm.expectRevert(IPositionManager.InsufficientUnlockedBalance.selector);
+        vm.prank(marketplace);
+        positionManager.lockForListing(alice, TOKEN_ID, 40);
     }
 
     function testUnlockForListingRevertsWhenLockedBalanceInsufficient() public {
@@ -298,8 +311,10 @@ contract PositionManagerTest is Test {
     }
 
     function testSettleLockedTransferConsumesLockBeforeTokenMove() public {
+        _mockRevenueTokenBalance(alice, TOKEN_ID, 100);
+
         vm.prank(marketplace);
-        positionManager.lockForListing(alice, TOKEN_ID, 55, 100);
+        positionManager.lockForListing(alice, TOKEN_ID, 55);
 
         vm.expectEmit(true, true, false, true, address(positionManager));
         emit ListingUnlocked(alice, TOKEN_ID, 20);
@@ -313,8 +328,10 @@ contract PositionManagerTest is Test {
     }
 
     function testSettleLockedTransferRevertsForInvalidMove() public {
+        _mockRevenueTokenBalance(alice, TOKEN_ID, 100);
+
         vm.prank(marketplace);
-        positionManager.lockForListing(alice, TOKEN_ID, 10, 100);
+        positionManager.lockForListing(alice, TOKEN_ID, 10);
 
         vm.expectRevert(IPositionManager.InsufficientLockedBalance.selector);
         vm.prank(marketplace);
@@ -403,7 +420,7 @@ contract PositionManagerTest is Test {
             )
         );
         vm.prank(unauthorized);
-        positionManager.lockForListing(alice, TOKEN_ID, 1, 1);
+        positionManager.lockForListing(alice, TOKEN_ID, 1);
     }
 
     function testAuthorizedRouterCanRecordPositionLock() public {
@@ -470,5 +487,9 @@ contract PositionManagerTest is Test {
         );
 
         return PositionManager(address(proxy));
+    }
+
+    function _mockRevenueTokenBalance(address holder, uint256 tokenId, uint256 balance) internal {
+        vm.mockCall(roboshareTokens, abi.encodeCall(IERC1155.balanceOf, (holder, tokenId)), abi.encode(balance));
     }
 }


### PR DESCRIPTION
## Summary
- add manager-owned listing lock APIs and bookkeeping to `IPositionManager` and `PositionManager`
- add locked transfer settlement and sale-penalty snapshot storage for Marketplace rewiring
- add focused `PositionManager` unit coverage for lock, unlock, locked transfer, and sale-penalty failure modes

## Verification
- `forge test --offline --match-path test/unit/PositionManager.t.sol`
- `yarn evm:compile`
- `git diff --check`