### PR TITLE
feat(evm): add revenue token manager hook (ROB-74)

### DIFF
--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -184,6 +184,29 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         );
     }
 
+    function beforeRevenueTokenUpdate(address from, address to, uint256 tokenId, uint256 amount) external {
+        if (msg.sender != roboshareTokens) {
+            revert UnauthorizedTokenHookCaller(msg.sender);
+        }
+
+        _requireRevenueToken(tokenId);
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[tokenId];
+        if (tokenInfo.tokenId == 0) {
+            tokenInfo.tokenId = tokenId;
+        }
+
+        if (from == address(0)) {
+            tokenInfo.tokenSupply += amount;
+            TokenLib.addPosition(tokenInfo, to, amount);
+        } else if (to == address(0)) {
+            tokenInfo.tokenSupply -= amount;
+            TokenLib.removePosition(tokenInfo, from, amount);
+        } else {
+            _transferPositionsFifo(tokenInfo, from, to, amount);
+        }
+    }
+
     function getUserPositions(uint256 revenueTokenId, address holder)
         external
         view
@@ -322,5 +345,53 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
+    }
+
+    function _transferPositionsFifo(TokenLib.TokenInfo storage info, address from, address to, uint256 amount)
+        internal
+    {
+        TokenLib.PositionQueue storage queue = info.positions[from];
+        uint256 remaining = amount;
+
+        for (uint256 i = queue.head; i < queue.tail && remaining > 0; i++) {
+            TokenLib.TokenPosition storage pos = queue.items[i];
+            if (pos.amount == 0) continue;
+
+            uint256 toMove = remaining > pos.amount ? pos.amount : remaining;
+            uint256 epoch = pos.redemptionEpoch;
+            uint256 acquiredAt = pos.acquiredAt;
+
+            pos.amount -= toMove;
+            if (pos.amount == 0) {
+                pos.soldAt = block.timestamp;
+            }
+
+            _appendPosition(info, to, toMove, acquiredAt, epoch);
+            remaining -= toMove;
+        }
+
+        if (remaining > 0) {
+            revert TokenLib.InsufficientTokenBalance();
+        }
+    }
+
+    function _appendPosition(
+        TokenLib.TokenInfo storage info,
+        address holder,
+        uint256 amount,
+        uint256 acquiredAt,
+        uint256 redemptionEpoch
+    ) internal {
+        TokenLib.PositionQueue storage queue = info.positions[holder];
+        uint256 id = queue.tail;
+        queue.items[id] = TokenLib.TokenPosition({
+            uid: id,
+            tokenId: info.tokenId,
+            amount: amount,
+            acquiredAt: acquiredAt,
+            soldAt: 0,
+            redemptionEpoch: redemptionEpoch
+        });
+        queue.tail++;
     }
 }

--- a/protocols/evm/contracts/RoboshareTokens.sol
+++ b/protocols/evm/contracts/RoboshareTokens.sol
@@ -9,6 +9,7 @@ import {
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { ProtocolLib, TokenLib } from "./Libraries.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
 
 /**
  * @title RoboshareTokens
@@ -56,12 +57,14 @@ contract RoboshareTokens is
         uint256 indexed revenueTokenId, uint256 redemptionEpoch, uint256 epochSupply, uint256 backedPrincipal
     );
     event TokenMetadataURISet(uint256 indexed tokenId, string metadataURI);
+    event PositionManagerUpdated(address indexed previousManager, address indexed newManager);
 
     // Token state
     uint256 private _tokenIdCounter;
     mapping(uint256 => TokenLib.TokenInfo) private _revenueTokenInfos;
     mapping(address => mapping(uint256 => uint256)) private _lockedRevenueTokenAmounts;
     mapping(uint256 => string) private _tokenMetadataURIs;
+    IPositionManager public positionManager;
     bool private _currentEpochBurnActive;
     address private _currentEpochBurnHolder;
     uint256 private _currentEpochBurnTokenId;
@@ -196,6 +199,15 @@ contract RoboshareTokens is
      */
     function setURI(string memory newuri) external onlyRole(URI_SETTER_ROLE) {
         _setURI(newuri);
+    }
+
+    function setPositionManager(address newPositionManager) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newPositionManager == address(0)) revert ZeroAddress();
+
+        address previousManager = address(positionManager);
+        positionManager = IPositionManager(newPositionManager);
+
+        emit PositionManagerUpdated(previousManager, newPositionManager);
     }
 
     /**
@@ -566,6 +578,13 @@ contract RoboshareTokens is
                 uint256 lockedAmount = _lockedRevenueTokenAmounts[from][tokenId];
                 uint256 available = balanceOf(from, tokenId) - lockedAmount;
                 if (cumulative > available) revert InsufficientUnlockedBalance();
+            }
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            uint256 tokenId = ids[i];
+            if (TokenLib.isRevenueToken(tokenId) && address(positionManager) != address(0)) {
+                positionManager.beforeRevenueTokenUpdate(from, to, tokenId, values[i]);
             }
         }
 

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -102,6 +102,7 @@ interface IPositionManager {
     error InvalidAmount();
     error InsufficientUnlockedBalance();
     error InsufficientLockedBalance();
+    error UnauthorizedTokenHookCaller(address caller);
     error UnsupportedPositionMutation(PositionMutationType mutationType);
 
     function initialize(
@@ -159,6 +160,8 @@ interface IPositionManager {
     function clearSalePenalty(uint256 listingId) external;
 
     function getSalePenalty(uint256 listingId) external view returns (uint256);
+
+    function beforeRevenueTokenUpdate(address from, address to, uint256 tokenId, uint256 amount) external;
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
         external;

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -7,6 +7,31 @@ import { AssetMetadataBaseTest } from "../base/AssetMetadataBaseTest.t.sol";
 import { TokenLib } from "../../contracts/Libraries.sol";
 import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
 
+contract MockPositionManager {
+    error HookBlocked();
+
+    uint256 public callCount;
+    address public lastFrom;
+    address public lastTo;
+    uint256 public lastTokenId;
+    uint256 public lastAmount;
+    bool public shouldRevert;
+
+    function setShouldRevert(bool value) external {
+        shouldRevert = value;
+    }
+
+    function beforeRevenueTokenUpdate(address from, address to, uint256 tokenId, uint256 amount) external {
+        if (shouldRevert) revert HookBlocked();
+
+        callCount++;
+        lastFrom = from;
+        lastTo = to;
+        lastTokenId = tokenId;
+        lastAmount = amount;
+    }
+}
+
 contract RoboshareTokensTest is AssetMetadataBaseTest {
     address public minter;
     address public burner;
@@ -254,6 +279,56 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         );
         vm.prank(unauthorized);
         roboshareTokens.setURI("ipfs://new-uri");
+    }
+
+    function testRevenueTokenMintCallsPositionManagerHook() public {
+        MockPositionManager mockManager = new MockPositionManager();
+
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(mockManager));
+
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        assertEq(mockManager.callCount(), 1);
+        assertEq(mockManager.lastFrom(), address(0));
+        assertEq(mockManager.lastTo(), user1);
+        assertEq(mockManager.lastTokenId(), tokenId);
+        assertEq(mockManager.lastAmount(), 100);
+    }
+
+    function testRevenueTokenTransferCallsPositionManagerHook() public {
+        MockPositionManager mockManager = new MockPositionManager();
+
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(mockManager));
+
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        vm.prank(user1);
+        roboshareTokens.safeTransferFrom(user1, user2, tokenId, 25, "");
+
+        assertEq(mockManager.callCount(), 2);
+        assertEq(mockManager.lastFrom(), user1);
+        assertEq(mockManager.lastTo(), user2);
+        assertEq(mockManager.lastTokenId(), tokenId);
+        assertEq(mockManager.lastAmount(), 25);
+    }
+
+    function testRevenueTokenBurnRevertsWhenPositionManagerHookReverts() public {
+        MockPositionManager mockManager = new MockPositionManager();
+
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(mockManager));
+
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        mockManager.setShouldRevert(true);
+
+        vm.expectRevert(MockPositionManager.HookBlocked.selector);
+        vm.prank(burner);
+        roboshareTokens.burn(user1, tokenId, 10);
+
+        assertEq(roboshareTokens.balanceOf(user1, tokenId), 100);
     }
 
     function testGetUserPositionsAndBalance() public {


### PR DESCRIPTION
## Summary
- add a configurable `positionManager` reference on `RoboshareTokens`
- call `beforeRevenueTokenUpdate(from, to, tokenId, amount)` before revenue-token mint, transfer, and burn balance updates finalize
- implement the matching manager-side hook path and add focused token-hook coverage

## Verification
- `yarn workspace evm format`
- `yarn workspace evm lint`
- `yarn workspace evm compile`
- `forge test --offline --match-path test/unit/RoboshareTokens.t.sol --match-test 'testRevenueToken'`
- `git diff --check`

Refs ROB-74