### PR TITLE
feat(evm): move redemption and settlement state into manager (ROB-73)

### DIFF
--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -8,12 +8,30 @@ import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import { TokenLib } from "./Libraries.sol";
 import { IPositionManager } from "./interfaces/IPositionManager.sol";
 
+interface IRoboshareTokenPriceReader {
+    function getTokenPrice(uint256 revenueTokenId) external view returns (uint256);
+}
+
 /**
  * @title PositionManager
  * @notice Upgradeable boundary contract for position, lock, redemption-epoch, and settlement state.
  * @dev This scaffold intentionally keeps redemption and settlement responsibilities in the same manager.
  */
 contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgradeable, IPositionManager {
+    struct SettlementStateInternal {
+        bool isConfigured;
+        uint256 epochId;
+        uint256 settlementAmount;
+        uint256 settlementPerToken;
+        uint256 claimedBurnAmount;
+        uint256 claimedPayout;
+    }
+
+    struct SettlementClaimStateInternal {
+        uint256 burnedAmount;
+        uint256 payout;
+    }
+
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     bytes32 public constant POSITION_ADMIN_ROLE = keccak256("POSITION_ADMIN_ROLE");
     bytes32 public constant AUTHORIZED_ROUTER_ROLE = keccak256("AUTHORIZED_ROUTER_ROLE");
@@ -30,6 +48,8 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     mapping(uint256 => TokenLib.TokenInfo) private _revenueTokenInfos;
     mapping(address => mapping(uint256 => uint256)) private _lockedAmounts;
     mapping(uint256 => uint256) private _listingSalePenalties;
+    mapping(uint256 => SettlementStateInternal) private _settlementStates;
+    mapping(uint256 => mapping(uint256 => mapping(address => SettlementClaimStateInternal))) private _settlementClaims;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -166,9 +186,10 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         if (mutation.mutationType == PositionMutationType.Mint) {
             tokenInfo.tokenSupply += mutation.amount;
             TokenLib.addPosition(tokenInfo, mutation.account, mutation.amount);
+            _increaseCurrentEpochState(tokenInfo, mutation.tokenId, mutation.amount);
         } else if (mutation.mutationType == PositionMutationType.Burn) {
             tokenInfo.tokenSupply -= mutation.amount;
-            TokenLib.removePosition(tokenInfo, mutation.account, mutation.amount);
+            _burnPositionsFifo(tokenInfo, mutation.account, mutation.amount);
         } else {
             revert UnsupportedPositionMutation(mutation.mutationType);
         }
@@ -199,9 +220,10 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         if (from == address(0)) {
             tokenInfo.tokenSupply += amount;
             TokenLib.addPosition(tokenInfo, to, amount);
+            _increaseCurrentEpochState(tokenInfo, tokenId, amount);
         } else if (to == address(0)) {
             tokenInfo.tokenSupply -= amount;
-            TokenLib.removePosition(tokenInfo, from, amount);
+            _burnPositionsFifo(tokenInfo, from, amount);
         } else {
             _transferPositionsFifo(tokenInfo, from, to, amount);
         }
@@ -240,6 +262,40 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
             return 0;
         }
         return totalBalance - lockedAmount;
+    }
+
+    function getPrimaryRedemptionEligibleBalance(address holder, uint256 revenueTokenId)
+        external
+        view
+        returns (uint256 eligibleBalance)
+    {
+        _requireRevenueToken(revenueTokenId);
+
+        TokenLib.TokenInfo storage info = _revenueTokenInfos[revenueTokenId];
+        TokenLib.PositionQueue storage queue = info.positions[holder];
+        uint256 currentEpoch = info.currentRedemptionEpoch;
+
+        for (uint256 i = queue.head; i < queue.tail; i++) {
+            TokenLib.TokenPosition storage position = queue.items[i];
+            if (position.amount > 0 && position.redemptionEpoch == currentEpoch) {
+                eligibleBalance += position.amount;
+            }
+        }
+    }
+
+    function getCurrentPrimaryRedemptionEpoch(uint256 revenueTokenId) external view returns (uint256) {
+        _requireRevenueToken(revenueTokenId);
+        return _revenueTokenInfos[revenueTokenId].currentRedemptionEpoch;
+    }
+
+    function getCurrentPrimaryRedemptionEpochSupply(uint256 revenueTokenId) external view returns (uint256) {
+        _requireRevenueToken(revenueTokenId);
+        return _revenueTokenInfos[revenueTokenId].currentRedemptionEpochSupply;
+    }
+
+    function getCurrentPrimaryRedemptionBackedPrincipal(uint256 revenueTokenId) external view returns (uint256) {
+        _requireRevenueToken(revenueTokenId);
+        return _revenueTokenInfos[revenueTokenId].currentRedemptionBackedPrincipal;
     }
 
     function lockForListing(address holder, uint256 revenueTokenId, uint256 amount)
@@ -311,11 +367,85 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         emit PositionLockUpdated(assetId, tokenId, account, lockUntil, reason);
     }
 
-    function recordRedemptionEpoch(uint256 tokenId, uint256 epochId, uint256 redeemableSupply, bytes32 reason)
+    function recordRedemptionEpoch(
+        uint256 tokenId,
+        uint256 epochId,
+        uint256 redeemableSupply,
+        uint256 backedPrincipal,
+        bytes32 reason
+    ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        _requireRevenueToken(tokenId);
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[tokenId];
+        if (tokenInfo.tokenId == 0) {
+            tokenInfo.tokenId = tokenId;
+        }
+
+        tokenInfo.currentRedemptionEpoch = epochId;
+        tokenInfo.currentRedemptionEpochSupply = redeemableSupply;
+        tokenInfo.currentRedemptionBackedPrincipal = backedPrincipal;
+
+        emit RedemptionStateUpdated(tokenId, epochId, redeemableSupply, backedPrincipal, reason);
+    }
+
+    function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason)
         external
         onlyRole(AUTHORIZED_TREASURY_ROLE)
     {
-        emit RedemptionEpochUpdated(tokenId, epochId, redeemableSupply, reason);
+        _requireRevenueToken(tokenId);
+        if (releasedAmount == 0) {
+            return;
+        }
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[tokenId];
+        uint256 backedPrincipal = tokenInfo.currentRedemptionBackedPrincipal;
+        if (backedPrincipal == 0) {
+            return;
+        }
+
+        tokenInfo.currentRedemptionBackedPrincipal =
+            releasedAmount >= backedPrincipal ? 0 : backedPrincipal - releasedAmount;
+
+        _rollRedemptionEpochIfExhausted(tokenInfo);
+
+        emit RedemptionStateUpdated(
+            tokenId,
+            tokenInfo.currentRedemptionEpoch,
+            tokenInfo.currentRedemptionEpochSupply,
+            tokenInfo.currentRedemptionBackedPrincipal,
+            reason
+        );
+    }
+
+    function consumePrimaryRedemption(
+        address holder,
+        uint256 tokenId,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        _requireRevenueToken(tokenId);
+        if (burnAmount == 0) {
+            revert InvalidAmount();
+        }
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[tokenId];
+        uint256 currentEpoch = tokenInfo.currentRedemptionEpoch;
+        // Token-side burns already flow through beforeRevenueTokenUpdate(...), so this
+        // transition only consumes the remaining backed principal and epoch aggregate state.
+        uint256 backedPrincipal = tokenInfo.currentRedemptionBackedPrincipal;
+        tokenInfo.currentRedemptionBackedPrincipal = payout >= backedPrincipal ? 0 : backedPrincipal - payout;
+
+        _rollRedemptionEpochIfExhausted(tokenInfo);
+
+        emit PrimaryRedemptionConsumed(tokenId, currentEpoch, holder, burnAmount, payout, reason);
+        emit RedemptionStateUpdated(
+            tokenId,
+            tokenInfo.currentRedemptionEpoch,
+            tokenInfo.currentRedemptionEpochSupply,
+            tokenInfo.currentRedemptionBackedPrincipal,
+            reason
+        );
     }
 
     function recordSettlement(
@@ -325,6 +455,16 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         uint256 settlementPerToken,
         bytes32 reason
     ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        SettlementStateInternal storage state = _settlementStates[assetId];
+        if (!state.isConfigured || state.epochId != epochId) {
+            state.claimedBurnAmount = 0;
+            state.claimedPayout = 0;
+        }
+        state.isConfigured = true;
+        state.epochId = epochId;
+        state.settlementAmount = settlementAmount;
+        state.settlementPerToken = settlementPerToken;
+
         emit SettlementConfigured(assetId, epochId, settlementAmount, settlementPerToken, reason);
     }
 
@@ -336,7 +476,48 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         uint256 payout,
         bytes32 reason
     ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        SettlementStateInternal storage state = _settlementStates[assetId];
+        if (!state.isConfigured) {
+            revert SettlementNotConfigured(assetId);
+        }
+
+        SettlementClaimStateInternal storage claimState = _settlementClaims[assetId][state.epochId][account];
+        claimState.burnedAmount += burnAmount;
+        claimState.payout += payout;
+        state.claimedBurnAmount += burnAmount;
+        state.claimedPayout += payout;
+
         emit SettlementClaimRecorded(assetId, tokenId, account, burnAmount, payout, reason);
+    }
+
+    function getSettlementState(uint256 assetId) external view returns (SettlementState memory state) {
+        SettlementStateInternal storage settlement = _settlementStates[assetId];
+        state = SettlementState({
+            isConfigured: settlement.isConfigured,
+            epochId: settlement.epochId,
+            settlementAmount: settlement.settlementAmount,
+            settlementPerToken: settlement.settlementPerToken,
+            claimedBurnAmount: settlement.claimedBurnAmount,
+            claimedPayout: settlement.claimedPayout
+        });
+    }
+
+    function getSettlementClaimState(uint256 assetId, address account)
+        external
+        view
+        returns (SettlementClaimState memory state)
+    {
+        uint256 epochId = _settlementStates[assetId].epochId;
+        SettlementClaimStateInternal storage claimState = _settlementClaims[assetId][epochId][account];
+        state = SettlementClaimState({ burnedAmount: claimState.burnedAmount, payout: claimState.payout });
+    }
+
+    function previewSettlementClaim(uint256 assetId, uint256 burnAmount) external view returns (uint256 payout) {
+        SettlementStateInternal storage settlement = _settlementStates[assetId];
+        if (!settlement.isConfigured || burnAmount == 0) {
+            return 0;
+        }
+        return burnAmount * settlement.settlementPerToken;
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
@@ -344,6 +525,53 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     function _requireRevenueToken(uint256 revenueTokenId) internal pure {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
+        }
+    }
+
+    function _increaseCurrentEpochState(TokenLib.TokenInfo storage info, uint256 tokenId, uint256 amount) internal {
+        uint256 tokenPrice = IRoboshareTokenPriceReader(roboshareTokens).getTokenPrice(tokenId);
+        info.currentRedemptionEpochSupply += amount;
+        info.currentRedemptionBackedPrincipal += amount * tokenPrice;
+    }
+
+    function _rollRedemptionEpochIfExhausted(TokenLib.TokenInfo storage info) internal {
+        if (info.currentRedemptionEpochSupply > 0 && info.currentRedemptionBackedPrincipal > 0) {
+            return;
+        }
+
+        info.currentRedemptionEpoch++;
+        info.currentRedemptionEpochSupply = 0;
+        info.currentRedemptionBackedPrincipal = 0;
+    }
+
+    function _burnPositionsFifo(TokenLib.TokenInfo storage info, address holder, uint256 amount) internal {
+        TokenLib.PositionQueue storage queue = info.positions[holder];
+        uint256 remaining = amount;
+        uint256 currentEpoch = info.currentRedemptionEpoch;
+        uint256 burnedFromCurrentEpoch = 0;
+
+        for (uint256 i = queue.head; i < queue.tail && remaining > 0; i++) {
+            TokenLib.TokenPosition storage pos = queue.items[i];
+            if (pos.amount == 0) continue;
+
+            uint256 toBurn = remaining > pos.amount ? pos.amount : remaining;
+            if (pos.redemptionEpoch == currentEpoch) {
+                burnedFromCurrentEpoch += toBurn;
+            }
+
+            pos.amount -= toBurn;
+            if (pos.amount == 0) {
+                pos.soldAt = block.timestamp;
+            }
+            remaining -= toBurn;
+        }
+
+        if (remaining > 0) {
+            revert TokenLib.InsufficientTokenBalance();
+        }
+
+        if (burnedFromCurrentEpoch > 0) {
+            info.currentRedemptionEpochSupply -= burnedFromCurrentEpoch;
         }
     }
 

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -36,6 +36,20 @@ interface IPositionManager {
         bytes32 reason;
     }
 
+    struct SettlementState {
+        bool isConfigured;
+        uint256 epochId;
+        uint256 settlementAmount;
+        uint256 settlementPerToken;
+        uint256 claimedBurnAmount;
+        uint256 claimedPayout;
+    }
+
+    struct SettlementClaimState {
+        uint256 burnedAmount;
+        uint256 payout;
+    }
+
     event PositionManagerInitialized(
         address indexed admin,
         address indexed registryRouter,
@@ -76,8 +90,12 @@ interface IPositionManager {
         uint256 indexed assetId, uint256 indexed tokenId, address indexed account, uint256 lockUntil, bytes32 reason
     );
 
-    event RedemptionEpochUpdated(
-        uint256 indexed tokenId, uint256 indexed epochId, uint256 redeemableSupply, bytes32 reason
+    event RedemptionStateUpdated(
+        uint256 indexed tokenId,
+        uint256 indexed epochId,
+        uint256 redeemableSupply,
+        uint256 backedPrincipal,
+        bytes32 reason
     );
 
     event SettlementConfigured(
@@ -97,11 +115,22 @@ interface IPositionManager {
         bytes32 reason
     );
 
+    event PrimaryRedemptionConsumed(
+        uint256 indexed tokenId,
+        uint256 indexed epochId,
+        address indexed account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    );
+
     error ZeroAddress();
     error NotRevenueToken();
     error InvalidAmount();
     error InsufficientUnlockedBalance();
     error InsufficientLockedBalance();
+    error InsufficientRedemptionBalance();
+    error SettlementNotConfigured(uint256 assetId);
     error UnauthorizedTokenHookCaller(address caller);
     error UnsupportedPositionMutation(PositionMutationType mutationType);
 
@@ -149,6 +178,14 @@ interface IPositionManager {
         view
         returns (uint256);
 
+    function getPrimaryRedemptionEligibleBalance(address holder, uint256 revenueTokenId) external view returns (uint256);
+
+    function getCurrentPrimaryRedemptionEpoch(uint256 revenueTokenId) external view returns (uint256);
+
+    function getCurrentPrimaryRedemptionEpochSupply(uint256 revenueTokenId) external view returns (uint256);
+
+    function getCurrentPrimaryRedemptionBackedPrincipal(uint256 revenueTokenId) external view returns (uint256);
+
     function lockForListing(address holder, uint256 revenueTokenId, uint256 amount) external;
 
     function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount) external;
@@ -166,7 +203,23 @@ interface IPositionManager {
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
         external;
 
-    function recordRedemptionEpoch(uint256 tokenId, uint256 epochId, uint256 redeemableSupply, bytes32 reason) external;
+    function recordRedemptionEpoch(
+        uint256 tokenId,
+        uint256 epochId,
+        uint256 redeemableSupply,
+        uint256 backedPrincipal,
+        bytes32 reason
+    ) external;
+
+    function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason) external;
+
+    function consumePrimaryRedemption(
+        address holder,
+        uint256 tokenId,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    ) external;
 
     function recordSettlement(
         uint256 assetId,
@@ -184,4 +237,13 @@ interface IPositionManager {
         uint256 payout,
         bytes32 reason
     ) external;
+
+    function getSettlementState(uint256 assetId) external view returns (SettlementState memory state);
+
+    function getSettlementClaimState(uint256 assetId, address account)
+        external
+        view
+        returns (SettlementClaimState memory state);
+
+    function previewSettlementClaim(uint256 assetId, uint256 burnAmount) external view returns (uint256 payout);
 }

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -25,6 +25,7 @@ contract PositionManagerTest is Test {
 
     uint256 private constant ASSET_ID = 101;
     uint256 private constant TOKEN_ID = 102;
+    uint256 private constant TOKEN_PRICE = 10e6;
 
     bytes32 private constant PRIMARY_REASON = keccak256("primary");
     bytes32 private constant LISTING_REASON = keccak256("listing");
@@ -55,8 +56,12 @@ contract PositionManagerTest is Test {
         uint256 indexed assetId, uint256 indexed tokenId, address indexed account, uint256 lockUntil, bytes32 reason
     );
 
-    event RedemptionEpochUpdated(
-        uint256 indexed tokenId, uint256 indexed epochId, uint256 redeemableSupply, bytes32 reason
+    event RedemptionStateUpdated(
+        uint256 indexed tokenId,
+        uint256 indexed epochId,
+        uint256 redeemableSupply,
+        uint256 backedPrincipal,
+        bytes32 reason
     );
 
     event SettlementConfigured(
@@ -76,10 +81,19 @@ contract PositionManagerTest is Test {
         bytes32 reason
     );
 
+    event PrimaryRedemptionConsumed(
+        uint256 indexed tokenId,
+        uint256 indexed epochId,
+        address indexed account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    );
+
     function setUp() public {
-        positionManager = _deployPositionManager(
-            admin, registryRouter, roboshareTokens, partnerManager, marketplace, treasury, usdc
-        );
+        positionManager =
+            _deployPositionManager(admin, registryRouter, roboshareTokens, partnerManager, marketplace, treasury, usdc);
+        _mockTokenPrice(TOKEN_ID, TOKEN_PRICE);
     }
 
     function testInitialization() public view {
@@ -219,6 +233,10 @@ contract PositionManagerTest is Test {
         assertGt(positions[0].acquiredAt, 0);
         assertEq(positions[0].soldAt, 0);
         assertEq(positions[0].redemptionEpoch, 0);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpoch(TOKEN_ID), 0);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 100);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 100 * TOKEN_PRICE);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 100);
     }
 
     function testBurnConsumesPositionsFifo() public {
@@ -265,6 +283,8 @@ contract PositionManagerTest is Test {
         assertEq(positions[0].amount, 0);
         assertTrue(positions[0].soldAt > 0);
         assertEq(positions[1].amount, 30);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 30);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 30);
     }
 
     function testGetLockedAmountRevertsForNonRevenueToken() public {
@@ -435,8 +455,8 @@ contract PositionManagerTest is Test {
         vm.startPrank(treasury);
 
         vm.expectEmit(true, true, false, true, address(positionManager));
-        emit RedemptionEpochUpdated(TOKEN_ID, 1, 100, REDEEM_REASON);
-        positionManager.recordRedemptionEpoch(TOKEN_ID, 1, 100, REDEEM_REASON);
+        emit RedemptionStateUpdated(TOKEN_ID, 1, 100, 1000, REDEEM_REASON);
+        positionManager.recordRedemptionEpoch(TOKEN_ID, 1, 100, 1000, REDEEM_REASON);
 
         vm.expectEmit(true, true, false, true, address(positionManager));
         emit SettlementConfigured(ASSET_ID, 1, 1000, 10, SETTLE_REASON);
@@ -447,6 +467,120 @@ contract PositionManagerTest is Test {
         positionManager.recordSettlementClaim(ASSET_ID, TOKEN_ID, alice, 20, 200, CLAIM_REASON);
 
         vm.stopPrank();
+    }
+
+    function testConsumePrimaryRedemptionDoesNotDoubleConsumeBurnHookState() public {
+        vm.prank(treasury);
+        positionManager.recordRedemptionEpoch(TOKEN_ID, 2, 0, 0, REDEEM_REASON);
+
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 100,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(alice, address(0), TOKEN_ID, 40);
+
+        TokenLib.TokenPosition[] memory positionsAfterBurn = positionManager.getUserPositions(TOKEN_ID, alice);
+        assertEq(positionsAfterBurn[0].amount, 60);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 60);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 60);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 100 * TOKEN_PRICE);
+
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit PrimaryRedemptionConsumed(TOKEN_ID, 2, alice, 40, 40 * TOKEN_PRICE, REDEEM_REASON);
+        vm.expectEmit(true, true, false, true, address(positionManager));
+        emit RedemptionStateUpdated(TOKEN_ID, 2, 60, 60 * TOKEN_PRICE, REDEEM_REASON);
+
+        vm.prank(treasury);
+        positionManager.consumePrimaryRedemption(alice, TOKEN_ID, 40, 40 * TOKEN_PRICE, REDEEM_REASON);
+
+        TokenLib.TokenPosition[] memory positions = positionManager.getUserPositions(TOKEN_ID, alice);
+        assertEq(positions[0].amount, 60);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 60);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpoch(TOKEN_ID), 2);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 60);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 60 * TOKEN_PRICE);
+    }
+
+    function testRecordImmediateProceedsReleaseReducesBackedPrincipal() public {
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 100,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+
+        vm.expectEmit(true, true, false, true, address(positionManager));
+        emit RedemptionStateUpdated(TOKEN_ID, 0, 100, 60 * TOKEN_PRICE, REDEEM_REASON);
+
+        vm.prank(treasury);
+        positionManager.recordImmediateProceedsRelease(TOKEN_ID, 40 * TOKEN_PRICE, REDEEM_REASON);
+
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpoch(TOKEN_ID), 0);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 100);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 60 * TOKEN_PRICE);
+    }
+
+    function testSettlementStateTracksClaimTotals() public {
+        vm.startPrank(treasury);
+        positionManager.recordSettlement(ASSET_ID, 4, 900, 9, SETTLE_REASON);
+        assertEq(positionManager.previewSettlementClaim(ASSET_ID, 25), 225);
+
+        positionManager.recordSettlementClaim(ASSET_ID, TOKEN_ID, alice, 20, 180, CLAIM_REASON);
+        positionManager.recordSettlementClaim(ASSET_ID, TOKEN_ID, alice, 5, 45, CLAIM_REASON);
+        vm.stopPrank();
+
+        IPositionManager.SettlementState memory settlement = positionManager.getSettlementState(ASSET_ID);
+        assertTrue(settlement.isConfigured);
+        assertEq(settlement.epochId, 4);
+        assertEq(settlement.settlementAmount, 900);
+        assertEq(settlement.settlementPerToken, 9);
+        assertEq(settlement.claimedBurnAmount, 25);
+        assertEq(settlement.claimedPayout, 225);
+
+        IPositionManager.SettlementClaimState memory claimState =
+            positionManager.getSettlementClaimState(ASSET_ID, alice);
+        assertEq(claimState.burnedAmount, 25);
+        assertEq(claimState.payout, 225);
+    }
+
+    function testSettlementClaimsResetAcrossEpochs() public {
+        vm.startPrank(treasury);
+        positionManager.recordSettlement(ASSET_ID, 4, 900, 9, SETTLE_REASON);
+        positionManager.recordSettlementClaim(ASSET_ID, TOKEN_ID, alice, 20, 180, CLAIM_REASON);
+
+        positionManager.recordSettlement(ASSET_ID, 5, 500, 5, SETTLE_REASON);
+        vm.stopPrank();
+
+        IPositionManager.SettlementState memory settlement = positionManager.getSettlementState(ASSET_ID);
+        assertTrue(settlement.isConfigured);
+        assertEq(settlement.epochId, 5);
+        assertEq(settlement.settlementAmount, 500);
+        assertEq(settlement.settlementPerToken, 5);
+        assertEq(settlement.claimedBurnAmount, 0);
+        assertEq(settlement.claimedPayout, 0);
+
+        IPositionManager.SettlementClaimState memory claimState =
+            positionManager.getSettlementClaimState(ASSET_ID, alice);
+        assertEq(claimState.burnedAmount, 0);
+        assertEq(claimState.payout, 0);
+
+        assertEq(positionManager.previewSettlementClaim(ASSET_ID, 10), 50);
     }
 
     function testUpgradeAuthorizedCaller() public {
@@ -491,5 +625,9 @@ contract PositionManagerTest is Test {
 
     function _mockRevenueTokenBalance(address holder, uint256 tokenId, uint256 balance) internal {
         vm.mockCall(roboshareTokens, abi.encodeCall(IERC1155.balanceOf, (holder, tokenId)), abi.encode(balance));
+    }
+
+    function _mockTokenPrice(uint256 tokenId, uint256 price) internal {
+        vm.mockCall(roboshareTokens, abi.encodeWithSignature("getTokenPrice(uint256)", tokenId), abi.encode(price));
     }
 }


### PR DESCRIPTION
## Summary
- move redemption epoch aggregates and backed principal bookkeeping into `PositionManager`
- add manager-owned settlement configuration and epoch-scoped claim accounting APIs
- cover the live burn-hook redemption path and settlement epoch resets in focused manager unit tests

## Testing
- `forge test --offline --match-path test/unit/PositionManager.t.sol`
- `yarn evm:compile`
- `git diff --check`