### PR TITLE
feat(evm): remove token-owned position state (ROB-75)

### DIFF
--- a/protocols/evm/contracts/Libraries.sol
+++ b/protocols/evm/contracts/Libraries.sol
@@ -340,19 +340,19 @@ library TokenLib {
      */
     struct TokenInfo {
         uint256 tokenId; // ERC1155 token ID
-        uint256 tokenPrice; // Price per token in USDC (6 decimals)
+        uint256 tokenPrice; // Price per token in USDC (6 decimals), synced to PositionManager for live policy reads
         uint256 maxSupply; // Max primary-pool supply used for revenue split bounds
         uint256 tokenSupply; // Total number of tokens issued
-        uint256 minHoldingPeriod; // Minimum holding period before penalty-free transfer
+        uint256 minHoldingPeriod; // Minimum holding period before penalty-free transfer, synced to PositionManager
         uint256 maturityDate; // Date by which the revenue commitment ends
         uint256 revenueShareBP; // Max investor share of reported revenue (basis points)
         uint256 targetYieldBP; // Target yield for buffer benchmarks (basis points)
         bool immediateProceeds; // True: higher-upside profile, False: earlier-liquidity profile
         bool protectionEnabled; // True when protection buffer policy is enabled
-        uint256 currentRedemptionEpoch; // Current tranche for primary redemptions
-        uint256 currentRedemptionEpochSupply; // Outstanding claim units in current redemption tranche
-        uint256 currentRedemptionBackedPrincipal; // Remaining backed principal for current redemption tranche
-        // Track positions per user using Queue
+        uint256 currentRedemptionEpoch; // Manager-owned live state once PositionManager is wired
+        uint256 currentRedemptionEpochSupply; // Manager-owned live state once PositionManager is wired
+        uint256 currentRedemptionBackedPrincipal; // Manager-owned live state once PositionManager is wired
+        // Track positions per user using Queue; live ownership moves to PositionManager after the split.
         mapping(address => PositionQueue) positions;
     }
 

--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -5,7 +5,7 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import { TokenLib } from "./Libraries.sol";
+import { ProtocolLib, TokenLib } from "./Libraries.sol";
 import { IPositionManager } from "./interfaces/IPositionManager.sol";
 
 interface IRoboshareTokenPriceReader {
@@ -50,6 +50,9 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     mapping(uint256 => uint256) private _listingSalePenalties;
     mapping(uint256 => SettlementStateInternal) private _settlementStates;
     mapping(uint256 => mapping(uint256 => mapping(address => SettlementClaimStateInternal))) private _settlementClaims;
+    bool private _currentEpochBurnActive;
+    address private _currentEpochBurnHolder;
+    uint256 private _currentEpochBurnTokenId;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -205,6 +208,23 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         );
     }
 
+    function syncRevenueTokenPolicy(uint256 revenueTokenId, uint256 tokenPrice, uint256 minHoldingPeriod) external {
+        if (msg.sender != roboshareTokens && !hasRole(POSITION_ADMIN_ROLE, msg.sender)) {
+            revert UnauthorizedTokenHookCaller(msg.sender);
+        }
+
+        _requireRevenueToken(revenueTokenId);
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[revenueTokenId];
+        if (tokenInfo.tokenId == 0) {
+            tokenInfo.tokenId = revenueTokenId;
+        }
+
+        tokenInfo.tokenPrice = tokenPrice;
+        tokenInfo.minHoldingPeriod =
+            minHoldingPeriod < ProtocolLib.MONTHLY_INTERVAL ? ProtocolLib.MONTHLY_INTERVAL : minHoldingPeriod;
+    }
+
     function beforeRevenueTokenUpdate(address from, address to, uint256 tokenId, uint256 amount) external {
         if (msg.sender != roboshareTokens) {
             revert UnauthorizedTokenHookCaller(msg.sender);
@@ -222,8 +242,7 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
             TokenLib.addPosition(tokenInfo, to, amount);
             _increaseCurrentEpochState(tokenInfo, tokenId, amount);
         } else if (to == address(0)) {
-            tokenInfo.tokenSupply -= amount;
-            _burnPositionsFifo(tokenInfo, from, amount);
+            _burnRevenueToken(tokenInfo, from, tokenId, amount);
         } else {
             _transferPositionsFifo(tokenInfo, from, to, amount);
         }
@@ -298,10 +317,8 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         return _revenueTokenInfos[revenueTokenId].currentRedemptionBackedPrincipal;
     }
 
-    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount)
-        external
-        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
-    {
+    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount) external {
+        _requireTokenOrMarketplaceCaller();
         _requireRevenueToken(revenueTokenId);
         if (amount == 0) revert InvalidAmount();
 
@@ -313,10 +330,8 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         emit ListingLocked(holder, revenueTokenId, amount);
     }
 
-    function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount)
-        external
-        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
-    {
+    function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount) external {
+        _requireTokenOrMarketplaceCaller();
         _requireRevenueToken(revenueTokenId);
         if (amount == 0) revert InvalidAmount();
 
@@ -327,10 +342,8 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         emit ListingUnlocked(holder, revenueTokenId, amount);
     }
 
-    function settleLockedTransfer(address from, address to, uint256 revenueTokenId, uint256 amount)
-        external
-        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
-    {
+    function settleLockedTransfer(address from, address to, uint256 revenueTokenId, uint256 amount) external {
+        _requireTokenOrMarketplaceCaller();
         _requireRevenueToken(revenueTokenId);
         if (amount == 0) revert InvalidAmount();
 
@@ -358,6 +371,33 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
 
     function getSalePenalty(uint256 listingId) external view returns (uint256) {
         return _listingSalePenalties[listingId];
+    }
+
+    function getSalesPenalty(address seller, uint256 revenueTokenId, uint256 amount)
+        external
+        view
+        returns (uint256 penaltyAmount)
+    {
+        _requireRevenueToken(revenueTokenId);
+
+        uint256 assetId = TokenLib.getAssetIdFromTokenId(revenueTokenId);
+        if (IERC1155(roboshareTokens).balanceOf(seller, assetId) > 0) {
+            return 0;
+        }
+
+        return TokenLib.calculateSalesPenalty(_revenueTokenInfos[revenueTokenId], seller, amount);
+    }
+
+    function preparePrimaryRedemptionBurn(address holder, uint256 tokenId) external {
+        if (msg.sender != roboshareTokens) {
+            revert UnauthorizedTokenHookCaller(msg.sender);
+        }
+
+        _requireRevenueToken(tokenId);
+
+        _currentEpochBurnActive = true;
+        _currentEpochBurnHolder = holder;
+        _currentEpochBurnTokenId = tokenId;
     }
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
@@ -388,33 +428,14 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         emit RedemptionStateUpdated(tokenId, epochId, redeemableSupply, backedPrincipal, reason);
     }
 
-    function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason)
-        external
-        onlyRole(AUTHORIZED_TREASURY_ROLE)
-    {
-        _requireRevenueToken(tokenId);
-        if (releasedAmount == 0) {
-            return;
-        }
+    function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason) external {
+        _requireTokenOrTreasuryCaller();
+        _recordPrincipalRelease(tokenId, releasedAmount, reason);
+    }
 
-        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[tokenId];
-        uint256 backedPrincipal = tokenInfo.currentRedemptionBackedPrincipal;
-        if (backedPrincipal == 0) {
-            return;
-        }
-
-        tokenInfo.currentRedemptionBackedPrincipal =
-            releasedAmount >= backedPrincipal ? 0 : backedPrincipal - releasedAmount;
-
-        _rollRedemptionEpochIfExhausted(tokenInfo);
-
-        emit RedemptionStateUpdated(
-            tokenId,
-            tokenInfo.currentRedemptionEpoch,
-            tokenInfo.currentRedemptionEpochSupply,
-            tokenInfo.currentRedemptionBackedPrincipal,
-            reason
-        );
+    function recordPrimaryRedemptionPayout(uint256 tokenId, uint256 payoutAmount, bytes32 reason) external {
+        _requireTokenOrTreasuryCaller();
+        _recordPrincipalRelease(tokenId, payoutAmount, reason);
     }
 
     function consumePrimaryRedemption(
@@ -529,9 +550,38 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     }
 
     function _increaseCurrentEpochState(TokenLib.TokenInfo storage info, uint256 tokenId, uint256 amount) internal {
-        uint256 tokenPrice = IRoboshareTokenPriceReader(roboshareTokens).getTokenPrice(tokenId);
+        uint256 tokenPrice = info.tokenPrice;
+        if (tokenPrice == 0) {
+            tokenPrice = IRoboshareTokenPriceReader(roboshareTokens).getTokenPrice(tokenId);
+        }
         info.currentRedemptionEpochSupply += amount;
         info.currentRedemptionBackedPrincipal += amount * tokenPrice;
+    }
+
+    function _recordPrincipalRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason) internal {
+        _requireRevenueToken(tokenId);
+        if (releasedAmount == 0) {
+            return;
+        }
+
+        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[tokenId];
+        uint256 backedPrincipal = tokenInfo.currentRedemptionBackedPrincipal;
+        if (backedPrincipal == 0) {
+            return;
+        }
+
+        tokenInfo.currentRedemptionBackedPrincipal =
+            releasedAmount >= backedPrincipal ? 0 : backedPrincipal - releasedAmount;
+
+        _rollRedemptionEpochIfExhausted(tokenInfo);
+
+        emit RedemptionStateUpdated(
+            tokenId,
+            tokenInfo.currentRedemptionEpoch,
+            tokenInfo.currentRedemptionEpochSupply,
+            tokenInfo.currentRedemptionBackedPrincipal,
+            reason
+        );
     }
 
     function _rollRedemptionEpochIfExhausted(TokenLib.TokenInfo storage info) internal {
@@ -542,6 +592,22 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         info.currentRedemptionEpoch++;
         info.currentRedemptionEpochSupply = 0;
         info.currentRedemptionBackedPrincipal = 0;
+    }
+
+    function _burnRevenueToken(TokenLib.TokenInfo storage info, address holder, uint256 tokenId, uint256 amount)
+        internal
+    {
+        info.tokenSupply -= amount;
+
+        if (_currentEpochBurnActive && holder == _currentEpochBurnHolder && tokenId == _currentEpochBurnTokenId) {
+            _currentEpochBurnActive = false;
+            _currentEpochBurnHolder = address(0);
+            _currentEpochBurnTokenId = 0;
+            _burnCurrentEpochPositions(info, holder, amount);
+            return;
+        }
+
+        _burnPositionsFifo(info, holder, amount);
     }
 
     function _burnPositionsFifo(TokenLib.TokenInfo storage info, address holder, uint256 amount) internal {
@@ -573,6 +639,30 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         if (burnedFromCurrentEpoch > 0) {
             info.currentRedemptionEpochSupply -= burnedFromCurrentEpoch;
         }
+    }
+
+    function _burnCurrentEpochPositions(TokenLib.TokenInfo storage info, address holder, uint256 amount) internal {
+        TokenLib.PositionQueue storage queue = info.positions[holder];
+        uint256 remaining = amount;
+        uint256 currentEpoch = info.currentRedemptionEpoch;
+
+        for (uint256 i = queue.head; i < queue.tail && remaining > 0; i++) {
+            TokenLib.TokenPosition storage pos = queue.items[i];
+            if (pos.amount == 0 || pos.redemptionEpoch != currentEpoch) continue;
+
+            uint256 toBurn = remaining > pos.amount ? pos.amount : remaining;
+            pos.amount -= toBurn;
+            if (pos.amount == 0) {
+                pos.soldAt = block.timestamp;
+            }
+            remaining -= toBurn;
+        }
+
+        if (remaining > 0) {
+            revert TokenLib.InsufficientTokenBalance();
+        }
+
+        info.currentRedemptionEpochSupply -= amount;
     }
 
     function _transferPositionsFifo(TokenLib.TokenInfo storage info, address from, address to, uint256 amount)
@@ -621,5 +711,17 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
             redemptionEpoch: redemptionEpoch
         });
         queue.tail++;
+    }
+
+    function _requireTokenOrTreasuryCaller() internal view {
+        if (msg.sender != roboshareTokens && !hasRole(AUTHORIZED_TREASURY_ROLE, msg.sender)) {
+            revert UnauthorizedTokenHookCaller(msg.sender);
+        }
+    }
+
+    function _requireTokenOrMarketplaceCaller() internal view {
+        if (msg.sender != roboshareTokens && !hasRole(AUTHORIZED_MARKETPLACE_ROLE, msg.sender)) {
+            revert UnauthorizedTokenHookCaller(msg.sender);
+        }
     }
 }

--- a/protocols/evm/contracts/RoboshareTokens.sol
+++ b/protocols/evm/contracts/RoboshareTokens.sol
@@ -37,6 +37,7 @@ contract RoboshareTokens is
     error InsufficientUnlockedBalance();
     error InsufficientLockedBalance();
     error EmptyMetadataURI();
+    error PositionManagerNotSet();
 
     // Events
     event RevenueTokenPositionsUpdated(
@@ -62,9 +63,11 @@ contract RoboshareTokens is
     // Token state
     uint256 private _tokenIdCounter;
     mapping(uint256 => TokenLib.TokenInfo) private _revenueTokenInfos;
+    // Deprecated token-owned lock bookkeeping kept only for storage-layout compatibility.
     mapping(address => mapping(uint256 => uint256)) private _lockedRevenueTokenAmounts;
     mapping(uint256 => string) private _tokenMetadataURIs;
     IPositionManager public positionManager;
+    // Deprecated token-owned redemption burn context kept only for storage-layout compatibility.
     bool private _currentEpochBurnActive;
     address private _currentEpochBurnHolder;
     uint256 private _currentEpochBurnTokenId;
@@ -143,6 +146,9 @@ contract RoboshareTokens is
             immediateProceeds,
             protectionEnabled
         );
+        if (address(positionManager) != address(0)) {
+            positionManager.syncRevenueTokenPolicy(revenueTokenId, tokenInfo.tokenPrice, tokenInfo.minHoldingPeriod);
+        }
         emit RevenueTokenInfoSet(
             revenueTokenId, price, supply, maxSupply, maturityDate, immediateProceeds, protectionEnabled
         );
@@ -204,8 +210,11 @@ contract RoboshareTokens is
     function setPositionManager(address newPositionManager) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newPositionManager == address(0)) revert ZeroAddress();
 
+        IPositionManager manager = IPositionManager(newPositionManager);
+        _syncRevenueTokenPolicies(manager);
+
         address previousManager = address(positionManager);
-        positionManager = IPositionManager(newPositionManager);
+        positionManager = manager;
 
         emit PositionManagerUpdated(previousManager, newPositionManager);
     }
@@ -337,7 +346,7 @@ contract RoboshareTokens is
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
-        return _lockedRevenueTokenAmounts[holder][revenueTokenId];
+        return _requirePositionManager().getLockedAmount(holder, revenueTokenId);
     }
 
     function lockForListing(address holder, uint256 revenueTokenId, uint256 amount)
@@ -348,13 +357,7 @@ contract RoboshareTokens is
             revert NotRevenueToken();
         }
         if (amount == 0) revert InvalidLockAmount();
-
-        uint256 balance = balanceOf(holder, revenueTokenId);
-        uint256 lockedAmount = _lockedRevenueTokenAmounts[holder][revenueTokenId];
-        if (balance < lockedAmount + amount) revert InsufficientUnlockedBalance();
-
-        _lockedRevenueTokenAmounts[holder][revenueTokenId] = lockedAmount + amount;
-        emit RevenueTokenLocked(revenueTokenId, holder, amount);
+        _requirePositionManager().lockForListing(holder, revenueTokenId, amount);
     }
 
     function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount)
@@ -365,12 +368,7 @@ contract RoboshareTokens is
             revert NotRevenueToken();
         }
         if (amount == 0) revert InvalidLockAmount();
-
-        uint256 lockedAmount = _lockedRevenueTokenAmounts[holder][revenueTokenId];
-        if (lockedAmount < amount) revert InsufficientLockedBalance();
-
-        _lockedRevenueTokenAmounts[holder][revenueTokenId] = lockedAmount - amount;
-        emit RevenueTokenUnlocked(revenueTokenId, holder, amount);
+        _requirePositionManager().unlockForListing(holder, revenueTokenId, amount);
     }
 
     function burnCurrentEpochForPrimaryRedemption(address holder, uint256 revenueTokenId, uint256 amount)
@@ -381,16 +379,8 @@ contract RoboshareTokens is
             revert NotRevenueToken();
         }
         if (amount == 0) revert InvalidLockAmount();
-
-        _currentEpochBurnActive = true;
-        _currentEpochBurnHolder = holder;
-        _currentEpochBurnTokenId = revenueTokenId;
-
+        _requirePositionManager().preparePrimaryRedemptionBurn(holder, revenueTokenId);
         _burn(holder, revenueTokenId, amount);
-
-        _currentEpochBurnActive = false;
-        _currentEpochBurnHolder = address(0);
-        _currentEpochBurnTokenId = 0;
     }
 
     function recordImmediateProceedsRelease(uint256 revenueTokenId, uint256 releasedAmount)
@@ -401,22 +391,8 @@ contract RoboshareTokens is
             revert NotRevenueToken();
         }
         if (releasedAmount == 0) return;
-
-        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[revenueTokenId];
-        uint256 backedPrincipal = tokenInfo.currentRedemptionBackedPrincipal;
-        if (backedPrincipal == 0) return;
-
-        tokenInfo.currentRedemptionBackedPrincipal =
-            releasedAmount >= backedPrincipal ? 0 : backedPrincipal - releasedAmount;
-
-        _rollRedemptionEpochIfExhausted(tokenInfo);
-
-        emit PrimaryRedemptionStateUpdated(
-            revenueTokenId,
-            tokenInfo.currentRedemptionEpoch,
-            tokenInfo.currentRedemptionEpochSupply,
-            tokenInfo.currentRedemptionBackedPrincipal
-        );
+        _requirePositionManager()
+            .recordImmediateProceedsRelease(revenueTokenId, releasedAmount, keccak256("IMMEDIATE_PROCEEDS_RELEASE"));
     }
 
     function recordPrimaryRedemptionPayout(uint256 revenueTokenId, uint256 payoutAmount)
@@ -427,20 +403,8 @@ contract RoboshareTokens is
             revert NotRevenueToken();
         }
         if (payoutAmount == 0) return;
-
-        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[revenueTokenId];
-        uint256 backedPrincipal = tokenInfo.currentRedemptionBackedPrincipal;
-        tokenInfo.currentRedemptionBackedPrincipal =
-            payoutAmount >= backedPrincipal ? 0 : backedPrincipal - payoutAmount;
-
-        _rollRedemptionEpochIfExhausted(tokenInfo);
-
-        emit PrimaryRedemptionStateUpdated(
-            revenueTokenId,
-            tokenInfo.currentRedemptionEpoch,
-            tokenInfo.currentRedemptionEpochSupply,
-            tokenInfo.currentRedemptionBackedPrincipal
-        );
+        _requirePositionManager()
+            .recordPrimaryRedemptionPayout(revenueTokenId, payoutAmount, keccak256("PRIMARY_REDEMPTION_PAYOUT"));
     }
 
     function transferLockedForListing(
@@ -454,13 +418,8 @@ contract RoboshareTokens is
             revert NotRevenueToken();
         }
         if (amount == 0) revert InvalidLockAmount();
-
-        uint256 lockedAmount = _lockedRevenueTokenAmounts[from][revenueTokenId];
-        if (lockedAmount < amount) revert InsufficientLockedBalance();
-        _lockedRevenueTokenAmounts[from][revenueTokenId] = lockedAmount - amount;
-
+        _requirePositionManager().settleLockedTransfer(from, to, revenueTokenId, amount);
         _safeTransferFrom(from, to, revenueTokenId, amount, data);
-        emit RevenueTokenUnlocked(revenueTokenId, from, amount);
     }
 
     /**
@@ -477,17 +436,7 @@ contract RoboshareTokens is
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
-        TokenLib.TokenInfo storage info = _revenueTokenInfos[revenueTokenId];
-        TokenLib.PositionQueue storage queue = info.positions[holder];
-
-        uint256 size = queue.tail - queue.head;
-        positions = new TokenLib.TokenPosition[](size);
-
-        for (uint256 i = 0; i < size; i++) {
-            positions[i] = queue.items[queue.head + i];
-        }
-
-        return positions;
+        return _requirePositionManager().getUserPositions(revenueTokenId, holder);
     }
 
     function getPrimaryRedemptionEligibleBalance(address holder, uint256 revenueTokenId)
@@ -498,34 +447,21 @@ contract RoboshareTokens is
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
-
-        TokenLib.TokenInfo storage info = _revenueTokenInfos[revenueTokenId];
-        TokenLib.PositionQueue storage queue = info.positions[holder];
-        uint256 currentEpoch = info.currentRedemptionEpoch;
-        uint256 eligibleBalance = 0;
-
-        for (uint256 i = queue.head; i < queue.tail; i++) {
-            TokenLib.TokenPosition storage position = queue.items[i];
-            if (position.amount > 0 && position.redemptionEpoch == currentEpoch) {
-                eligibleBalance += position.amount;
-            }
-        }
-
-        return eligibleBalance;
+        return _requirePositionManager().getPrimaryRedemptionEligibleBalance(holder, revenueTokenId);
     }
 
     function getCurrentPrimaryRedemptionEpochSupply(uint256 revenueTokenId) external view returns (uint256) {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
-        return _revenueTokenInfos[revenueTokenId].currentRedemptionEpochSupply;
+        return _requirePositionManager().getCurrentPrimaryRedemptionEpochSupply(revenueTokenId);
     }
 
     function getCurrentPrimaryRedemptionBackedPrincipal(uint256 revenueTokenId) external view returns (uint256) {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
-        return _revenueTokenInfos[revenueTokenId].currentRedemptionBackedPrincipal;
+        return _requirePositionManager().getCurrentPrimaryRedemptionBackedPrincipal(revenueTokenId);
     }
 
     /**
@@ -544,15 +480,7 @@ contract RoboshareTokens is
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
-
-        // If the seller is the current owner of the corresponding Asset NFT, they are exempt from the penalty.
-        uint256 assetId = TokenLib.getAssetIdFromTokenId(revenueTokenId);
-        if (balanceOf(seller, assetId) > 0) {
-            penaltyAmount = 0;
-        } else {
-            // Otherwise, calculate the penalty based on token positions
-            penaltyAmount = TokenLib.calculateSalesPenalty(_revenueTokenInfos[revenueTokenId], seller, amount);
-        }
+        return _requirePositionManager().getSalesPenalty(seller, revenueTokenId, amount);
     }
 
     /**
@@ -560,9 +488,21 @@ contract RoboshareTokens is
      * Called on all mints, burns, and transfers.
      */
     function _update(address from, address to, uint256[] memory ids, uint256[] memory values) internal override {
+        IPositionManager manager;
+        bool hasRevenueToken;
+        for (uint256 i = 0; i < ids.length; i++) {
+            if (TokenLib.isRevenueToken(ids[i])) {
+                hasRevenueToken = true;
+                break;
+            }
+        }
+        if (hasRevenueToken) {
+            manager = _requirePositionManager();
+        }
+
         // Disallow transferring/burning listed (locked) revenue tokens through normal token paths.
         // Marketplace listing fills unlock before transfer via transferLockedForListing().
-        if (from != address(0)) {
+        if (hasRevenueToken && from != address(0)) {
             for (uint256 i = 0; i < ids.length; i++) {
                 uint256 tokenId = ids[i];
                 uint256 amount = values[i];
@@ -575,16 +515,15 @@ contract RoboshareTokens is
                     }
                 }
 
-                uint256 lockedAmount = _lockedRevenueTokenAmounts[from][tokenId];
-                uint256 available = balanceOf(from, tokenId) - lockedAmount;
+                uint256 available = manager.getAvailableAmount(from, tokenId, balanceOf(from, tokenId));
                 if (cumulative > available) revert InsufficientUnlockedBalance();
             }
         }
 
         for (uint256 i = 0; i < ids.length; i++) {
             uint256 tokenId = ids[i];
-            if (TokenLib.isRevenueToken(tokenId) && address(positionManager) != address(0)) {
-                positionManager.beforeRevenueTokenUpdate(from, to, tokenId, values[i]);
+            if (hasRevenueToken && TokenLib.isRevenueToken(tokenId)) {
+                manager.beforeRevenueTokenUpdate(from, to, tokenId, values[i]);
             }
         }
 
@@ -607,7 +546,6 @@ contract RoboshareTokens is
                     tokenInfo.tokenSupply -= amount;
                 }
 
-                _updateRevenueTokenPositions(tokenId, from, to, amount);
                 emit RevenueTokenPositionsUpdated(tokenId, from, to, amount);
             }
         }
@@ -625,156 +563,18 @@ contract RoboshareTokens is
         return super.supportsInterface(interfaceId);
     }
 
-    /**
-     * @dev Internal function to update token positions using FIFO logic.
-     * @param from The address transferring from (address(0) for mints).
-     * @param to The address transferring to (address(0) for burns).
-     * @param revenueTokenId The token ID being transferred.
-     * @param amount The amount being transferred.
-     */
-    function _updateRevenueTokenPositions(uint256 revenueTokenId, address from, address to, uint256 amount) internal {
-        TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[revenueTokenId];
-
-        if (from == address(0)) {
-            // Minting - add position to receiver in the current redemption tranche.
-            TokenLib.addPosition(tokenInfo, to, amount);
-            tokenInfo.currentRedemptionEpochSupply += amount;
-            tokenInfo.currentRedemptionBackedPrincipal += amount * tokenInfo.tokenPrice;
-            emit PrimaryRedemptionStateUpdated(
-                revenueTokenId,
-                tokenInfo.currentRedemptionEpoch,
-                tokenInfo.currentRedemptionEpochSupply,
-                tokenInfo.currentRedemptionBackedPrincipal
-            );
-        } else if (to == address(0)) {
-            if (
-                _currentEpochBurnActive && from == _currentEpochBurnHolder && revenueTokenId == _currentEpochBurnTokenId
-            ) {
-                _burnCurrentEpochPositions(tokenInfo, from, amount);
-            } else {
-                _burnPositionsFifo(tokenInfo, from, amount);
-            }
-        } else {
-            _transferPositionsFifo(tokenInfo, from, to, amount);
-        }
+    function _requirePositionManager() internal view returns (IPositionManager manager) {
+        manager = positionManager;
+        if (address(manager) == address(0)) revert PositionManagerNotSet();
     }
 
-    function _appendPositionWithEpoch(TokenLib.TokenInfo storage info, address holder, uint256 amount, uint256 epoch)
-        private
-    {
-        TokenLib.PositionQueue storage queue = info.positions[holder];
-        uint256 id = queue.tail;
-        queue.items[id] = TokenLib.TokenPosition({
-            uid: id,
-            tokenId: info.tokenId,
-            amount: amount,
-            acquiredAt: block.timestamp,
-            soldAt: 0,
-            redemptionEpoch: epoch
-        });
-        queue.tail++;
-    }
+    function _syncRevenueTokenPolicies(IPositionManager manager) internal {
+        for (uint256 revenueTokenId = 2; revenueTokenId < _tokenIdCounter; revenueTokenId += 2) {
+            TokenLib.TokenInfo storage tokenInfo = _revenueTokenInfos[revenueTokenId];
+            if (tokenInfo.tokenId == 0) continue;
 
-    function _rollRedemptionEpochIfExhausted(TokenLib.TokenInfo storage info) private {
-        if (info.currentRedemptionEpochSupply > 0 && info.currentRedemptionBackedPrincipal > 0) {
-            return;
+            manager.syncRevenueTokenPolicy(revenueTokenId, tokenInfo.tokenPrice, tokenInfo.minHoldingPeriod);
         }
-
-        info.currentRedemptionEpoch++;
-        info.currentRedemptionEpochSupply = 0;
-        info.currentRedemptionBackedPrincipal = 0;
-    }
-
-    function _transferPositionsFifo(TokenLib.TokenInfo storage info, address from, address to, uint256 amount) private {
-        TokenLib.PositionQueue storage queue = info.positions[from];
-        uint256 remaining = amount;
-
-        for (uint256 i = queue.head; i < queue.tail && remaining > 0; i++) {
-            TokenLib.TokenPosition storage pos = queue.items[i];
-            if (pos.amount == 0) continue;
-
-            uint256 toMove = remaining > pos.amount ? pos.amount : remaining;
-            uint256 epoch = pos.redemptionEpoch;
-
-            pos.amount -= toMove;
-            if (pos.amount == 0) {
-                pos.soldAt = block.timestamp;
-            }
-
-            _appendPositionWithEpoch(info, to, toMove, epoch);
-            remaining -= toMove;
-        }
-
-        if (remaining > 0) {
-            revert TokenLib.InsufficientTokenBalance();
-        }
-    }
-
-    function _burnPositionsFifo(TokenLib.TokenInfo storage info, address holder, uint256 amount) private {
-        TokenLib.PositionQueue storage queue = info.positions[holder];
-        uint256 remaining = amount;
-        uint256 currentEpoch = info.currentRedemptionEpoch;
-        uint256 burnedFromCurrentEpoch = 0;
-
-        for (uint256 i = queue.head; i < queue.tail && remaining > 0; i++) {
-            TokenLib.TokenPosition storage pos = queue.items[i];
-            if (pos.amount == 0) continue;
-
-            uint256 toBurn = remaining > pos.amount ? pos.amount : remaining;
-            if (pos.redemptionEpoch == currentEpoch) {
-                burnedFromCurrentEpoch += toBurn;
-            }
-
-            pos.amount -= toBurn;
-            if (pos.amount == 0) {
-                pos.soldAt = block.timestamp;
-            }
-            remaining -= toBurn;
-        }
-
-        if (remaining > 0) {
-            revert TokenLib.InsufficientTokenBalance();
-        }
-
-        if (burnedFromCurrentEpoch > 0) {
-            info.currentRedemptionEpochSupply -= burnedFromCurrentEpoch;
-            emit PrimaryRedemptionStateUpdated(
-                info.tokenId,
-                info.currentRedemptionEpoch,
-                info.currentRedemptionEpochSupply,
-                info.currentRedemptionBackedPrincipal
-            );
-        }
-    }
-
-    function _burnCurrentEpochPositions(TokenLib.TokenInfo storage info, address holder, uint256 amount) private {
-        TokenLib.PositionQueue storage queue = info.positions[holder];
-        uint256 remaining = amount;
-        uint256 currentEpoch = info.currentRedemptionEpoch;
-
-        for (uint256 i = queue.head; i < queue.tail && remaining > 0; i++) {
-            TokenLib.TokenPosition storage pos = queue.items[i];
-            if (pos.amount == 0 || pos.redemptionEpoch != currentEpoch) continue;
-
-            uint256 toBurn = remaining > pos.amount ? pos.amount : remaining;
-            pos.amount -= toBurn;
-            if (pos.amount == 0) {
-                pos.soldAt = block.timestamp;
-            }
-            remaining -= toBurn;
-        }
-
-        if (remaining > 0) {
-            revert TokenLib.InsufficientTokenBalance();
-        }
-
-        info.currentRedemptionEpochSupply -= amount;
-        emit PrimaryRedemptionStateUpdated(
-            info.tokenId,
-            info.currentRedemptionEpoch,
-            info.currentRedemptionEpochSupply,
-            info.currentRedemptionBackedPrincipal
-        );
     }
 
     /**

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -166,6 +166,8 @@ interface IPositionManager {
 
     function recordPositionMutation(PositionMutation calldata mutation) external;
 
+    function syncRevenueTokenPolicy(uint256 revenueTokenId, uint256 tokenPrice, uint256 minHoldingPeriod) external;
+
     function getUserPositions(uint256 revenueTokenId, address holder)
         external
         view
@@ -198,7 +200,14 @@ interface IPositionManager {
 
     function getSalePenalty(uint256 listingId) external view returns (uint256);
 
+    function getSalesPenalty(address seller, uint256 revenueTokenId, uint256 amount)
+        external
+        view
+        returns (uint256 penaltyAmount);
+
     function beforeRevenueTokenUpdate(address from, address to, uint256 tokenId, uint256 amount) external;
+
+    function preparePrimaryRedemptionBurn(address holder, uint256 tokenId) external;
 
     function recordPositionLock(uint256 assetId, uint256 tokenId, address account, uint256 lockUntil, bytes32 reason)
         external;
@@ -212,6 +221,8 @@ interface IPositionManager {
     ) external;
 
     function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason) external;
+
+    function recordPrimaryRedemptionPayout(uint256 tokenId, uint256 payoutAmount, bytes32 reason) external;
 
     function consumePrimaryRedemption(
         address holder,

--- a/protocols/evm/test/base/BaseTest.t.sol
+++ b/protocols/evm/test/base/BaseTest.t.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.19;
 
 import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { PositionManager } from "../../contracts/PositionManager.sol";
 import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
 import { PartnerManager } from "../../contracts/PartnerManager.sol";
 import { RegistryRouter } from "../../contracts/RegistryRouter.sol";
@@ -115,6 +117,10 @@ abstract contract BaseTest is Test {
 
         config = deployer.getActiveNetworkConfig();
         usdc = IERC20(config.usdcToken);
+
+        PositionManager positionManager = _deployPositionManager();
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(positionManager));
     }
 
     function _setupInitialRolesAndAccounts() internal {
@@ -138,6 +144,27 @@ abstract contract BaseTest is Test {
 
     function _fundAddressWithUsdc(address account, uint256 amount) internal {
         deal(address(usdc), account, amount);
+    }
+
+    function _deployPositionManager() internal returns (PositionManager) {
+        PositionManager implementation = new PositionManager();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            abi.encodeCall(
+                PositionManager.initialize,
+                (
+                    admin,
+                    address(router),
+                    address(roboshareTokens),
+                    address(partnerManager),
+                    address(marketplace),
+                    address(treasury),
+                    address(usdc)
+                )
+            )
+        );
+
+        return PositionManager(address(proxy));
     }
 
     function _setupAssetRegistered() internal virtual returns (uint256);

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -432,13 +432,7 @@ contract PositionManagerTest is Test {
     }
 
     function testUnauthorizedCallerCannotLockForListing() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                unauthorized,
-                positionManager.AUTHORIZED_MARKETPLACE_ROLE()
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.UnauthorizedTokenHookCaller.selector, unauthorized));
         vm.prank(unauthorized);
         positionManager.lockForListing(alice, TOKEN_ID, 1);
     }

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -5,6 +5,7 @@ import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.so
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { AssetMetadataBaseTest } from "../base/AssetMetadataBaseTest.t.sol";
 import { TokenLib } from "../../contracts/Libraries.sol";
+import { PositionManager } from "../../contracts/PositionManager.sol";
 import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
 
 contract MockPositionManager {
@@ -30,6 +31,48 @@ contract MockPositionManager {
         lastTokenId = tokenId;
         lastAmount = amount;
     }
+
+    function syncRevenueTokenPolicy(uint256, uint256, uint256) external { }
+
+    function getLockedAmount(address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getAvailableAmount(address, uint256, uint256 totalBalance) external pure returns (uint256) {
+        return totalBalance;
+    }
+
+    function getUserPositions(uint256, address) external pure returns (TokenLib.TokenPosition[] memory positions) {
+        positions = new TokenLib.TokenPosition[](0);
+    }
+
+    function getPrimaryRedemptionEligibleBalance(address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getCurrentPrimaryRedemptionEpochSupply(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getCurrentPrimaryRedemptionBackedPrincipal(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getSalesPenalty(address, uint256, uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function lockForListing(address, uint256, uint256) external { }
+
+    function unlockForListing(address, uint256, uint256) external { }
+
+    function settleLockedTransfer(address, address, uint256, uint256) external { }
+
+    function preparePrimaryRedemptionBurn(address, uint256) external { }
+
+    function recordImmediateProceedsRelease(uint256, uint256, bytes32) external { }
+
+    function recordPrimaryRedemptionPayout(uint256, uint256, bytes32) external { }
 }
 
 contract RoboshareTokensTest is AssetMetadataBaseTest {
@@ -37,6 +80,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     address public burner;
     address public user1 = makeAddr("user1");
     address public user2 = makeAddr("user2");
+    PositionManager public testPositionManager;
 
     function _setupBuffersFunded() internal override { }
 
@@ -44,6 +88,9 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
 
     function setUp() public {
         _ensureState(SetupState.ContractsDeployed);
+        testPositionManager = _deployPositionManager(address(roboshareTokens));
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(testPositionManager));
         minter = admin; // Admin has minter role by default
         burner = admin; // Admin has burner role by default
 
@@ -51,6 +98,27 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         // deterministic test users are EOAs even if the forked chain has code there.
         vm.etch(user1, bytes(""));
         vm.etch(user2, bytes(""));
+    }
+
+    function _deployPositionManager(address tokenAddress) internal returns (PositionManager) {
+        PositionManager implementation = new PositionManager();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            abi.encodeCall(
+                PositionManager.initialize,
+                (
+                    admin,
+                    address(router),
+                    tokenAddress,
+                    address(partnerManager),
+                    address(marketplace),
+                    address(treasury),
+                    address(usdc)
+                )
+            )
+        );
+
+        return PositionManager(address(proxy));
     }
 
     function _setupRevenueTokenForLocks(address holder, uint256 amount) internal returns (uint256 tokenId) {
@@ -329,6 +397,32 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.burn(user1, tokenId, 10);
 
         assertEq(roboshareTokens.balanceOf(user1, tokenId), 100);
+    }
+
+    function testSetPositionManagerBackfillsExistingRevenueTokenPolicy() public {
+        RoboshareTokens freshToken = RoboshareTokens(
+            address(
+                new ERC1967Proxy(address(new RoboshareTokens()), abi.encodeWithSignature("initialize(address)", admin))
+            )
+        );
+        PositionManager freshManager = _deployPositionManager(address(freshToken));
+
+        vm.prank(admin);
+        (, uint256 tokenId) = freshToken.reserveNextTokenIdPair();
+        uint256 amount = 100;
+        uint256 maturityDate = block.timestamp + 365 days;
+
+        vm.prank(admin);
+        freshToken.setRevenueTokenInfo(tokenId, 100 * 1e6, amount, amount, maturityDate, 10_000, 1_000, false, false);
+
+        vm.prank(admin);
+        freshToken.setPositionManager(address(freshManager));
+
+        vm.prank(admin);
+        freshToken.mint(user1, tokenId, amount, "");
+
+        uint256 penalty = freshToken.getSalesPenalty(user1, tokenId, amount);
+        assertGt(penalty, 0, "Penalty should use backfilled manager policy after late manager attach");
     }
 
     function testGetUserPositionsAndBalance() public {


### PR DESCRIPTION
## Summary
- move live revenue-token position, listing-lock, sale-penalty, and primary-redemption state out of `RoboshareTokens` and into `PositionManager`
- sync revenue-token policy into the manager on both configure-time and late manager attachment, with regression coverage for the late-attach path
- keep ROB-75 scoped to contracts and tests by leaving deploy-script wiring to ROB-83

## Verification
- forge test --offline --match-path test/unit/RoboshareTokens.t.sol
- yarn evm:compile
- git diff --check