### PR TITLE
feat(evm): add manager token paths (ROB-76)

### DIFF
--- a/protocols/evm/contracts/Marketplace.sol
+++ b/protocols/evm/contracts/Marketplace.sol
@@ -12,6 +12,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ProtocolLib, TokenLib, AssetLib, CollateralLib } from "./Libraries.sol";
 import { ITreasury } from "./interfaces/ITreasury.sol";
 import { IMarketplace } from "./interfaces/IMarketplace.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
 import { RoboshareTokens } from "./RoboshareTokens.sol";
 import { PartnerManager } from "./PartnerManager.sol";
 import { RegistryRouter } from "./RegistryRouter.sol";
@@ -387,7 +388,7 @@ contract Marketplace is
         });
 
         assetListings[assetId].push(listingId);
-        roboshareTokens.lockForListing(seller, tokenId, amount);
+        _positionManager().lockForListing(seller, tokenId, amount);
 
         emit ListingCreated(listingId, tokenId, assetId, seller, amount, pricePerToken, expiresAt, buyerPaysFee);
         return listingId;
@@ -429,7 +430,7 @@ contract Marketplace is
         listing.isActive = false;
 
         if (listing.amount > 0) {
-            roboshareTokens.unlockForListing(listing.seller, listing.tokenId, listing.amount);
+            _positionManager().unlockForListing(listing.seller, listing.tokenId, listing.amount);
             listing.amount = 0;
         }
 
@@ -690,7 +691,8 @@ contract Marketplace is
         }
 
         _routeProtocolFee(quote.protocolFee + quote.earlySalePenalty);
-        roboshareTokens.transferLockedForListing(listing.seller, buyer, listing.tokenId, amount, "");
+        _positionManager().settleLockedTransfer(listing.seller, buyer, listing.tokenId, amount);
+        roboshareTokens.safeTransferFrom(listing.seller, buyer, listing.tokenId, amount, "");
 
         emit RevenueTokensTraded(listing.tokenId, listing.seller, buyer, amount, listingId, quote.grossProceeds);
     }
@@ -700,7 +702,7 @@ contract Marketplace is
 
         listing.isActive = false;
         if (listing.amount > 0) {
-            roboshareTokens.unlockForListing(listing.seller, listing.tokenId, listing.amount);
+            _positionManager().unlockForListing(listing.seller, listing.tokenId, listing.amount);
             listing.amount = 0;
         }
         return true;
@@ -725,6 +727,10 @@ contract Marketplace is
         if (amount == 0) return;
         _transferUSDC(address(treasury), amount);
         treasury.recordPendingWithdrawalFor(treasury.treasuryFeeRecipient(), amount);
+    }
+
+    function _positionManager() internal view returns (IPositionManager) {
+        return roboshareTokens.positionManager();
     }
 
     function _isAssetMarketOperational(uint256 assetId) internal view returns (bool) {

--- a/protocols/evm/contracts/Marketplace.sol
+++ b/protocols/evm/contracts/Marketplace.sol
@@ -106,6 +106,8 @@ contract Marketplace is
     error InvalidDuration();
     error ListingOwnerCannotPurchase();
     error PrimaryRedemptionNotAllowed();
+    error PositionManagerNotSet();
+    error InvalidPositionManager(address manager);
 
     event PrimaryPoolCreated(
         uint256 indexed tokenId,
@@ -729,7 +731,10 @@ contract Marketplace is
     }
 
     function _positionManager() internal view returns (IPositionManager) {
-        return roboshareTokens.positionManager();
+        IPositionManager manager = roboshareTokens.positionManager();
+        if (address(manager) == address(0)) revert PositionManagerNotSet();
+        if (address(manager).code.length == 0) revert InvalidPositionManager(address(manager));
+        return manager;
     }
 
     function _isAssetMarketOperational(uint256 assetId) internal view returns (bool) {

--- a/protocols/evm/contracts/Marketplace.sol
+++ b/protocols/evm/contracts/Marketplace.sol
@@ -691,8 +691,7 @@ contract Marketplace is
         }
 
         _routeProtocolFee(quote.protocolFee + quote.earlySalePenalty);
-        _positionManager().settleLockedTransfer(listing.seller, buyer, listing.tokenId, amount);
-        roboshareTokens.safeTransferFrom(listing.seller, buyer, listing.tokenId, amount, "");
+        _positionManager().transferLockedForListing(listing.seller, buyer, listing.tokenId, amount);
 
         emit RevenueTokensTraded(listing.tokenId, listing.seller, buyer, amount, listingId, quote.grossProceeds);
     }

--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -12,6 +12,10 @@ interface IRoboshareTokenPriceReader {
     function getTokenPrice(uint256 revenueTokenId) external view returns (uint256);
 }
 
+interface IRoboshareTokenManager {
+    function managerBurnCurrentEpoch(address holder, uint256 revenueTokenId, uint256 amount) external;
+}
+
 /**
  * @title PositionManager
  * @notice Upgradeable boundary contract for position, lock, redemption-epoch, and settlement state.
@@ -355,6 +359,16 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         emit LockedTransferSettled(from, to, revenueTokenId, amount);
     }
 
+    function burnCurrentEpochForPrimaryRedemption(address holder, uint256 tokenId, uint256 amount)
+        external
+        onlyRole(AUTHORIZED_ROUTER_ROLE)
+    {
+        _requireRevenueToken(tokenId);
+        if (amount == 0) revert InvalidAmount();
+
+        IRoboshareTokenManager(roboshareTokens).managerBurnCurrentEpoch(holder, tokenId, amount);
+    }
+
     function bookSalePenalty(uint256 listingId, address seller, uint256 revenueTokenId, uint256 amount)
         external
         onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
@@ -429,12 +443,12 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
     }
 
     function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount, bytes32 reason) external {
-        _requireTokenOrTreasuryCaller();
+        _requireTokenRouterOrTreasuryCaller();
         _recordPrincipalRelease(tokenId, releasedAmount, reason);
     }
 
     function recordPrimaryRedemptionPayout(uint256 tokenId, uint256 payoutAmount, bytes32 reason) external {
-        _requireTokenOrTreasuryCaller();
+        _requireTokenRouterOrTreasuryCaller();
         _recordPrincipalRelease(tokenId, payoutAmount, reason);
     }
 
@@ -713,8 +727,11 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         queue.tail++;
     }
 
-    function _requireTokenOrTreasuryCaller() internal view {
-        if (msg.sender != roboshareTokens && !hasRole(AUTHORIZED_TREASURY_ROLE, msg.sender)) {
+    function _requireTokenRouterOrTreasuryCaller() internal view {
+        if (
+            msg.sender != roboshareTokens && !hasRole(AUTHORIZED_ROUTER_ROLE, msg.sender)
+                && !hasRole(AUTHORIZED_TREASURY_ROLE, msg.sender)
+        ) {
             revert UnauthorizedTokenHookCaller(msg.sender);
         }
     }

--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -374,7 +374,7 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         _requireRevenueToken(revenueTokenId);
         if (amount == 0) revert InvalidAmount();
 
-        IRoboshareTokenManager(roboshareTokens).transferLockedForListing(from, to, revenueTokenId, amount, "");
+        _roboshareTokenManager().transferLockedForListing(from, to, revenueTokenId, amount, "");
     }
 
     function burnCurrentEpochForPrimaryRedemption(address holder, uint256 tokenId, uint256 amount)
@@ -384,7 +384,7 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         _requireRevenueToken(tokenId);
         if (amount == 0) revert InvalidAmount();
 
-        IRoboshareTokenManager(roboshareTokens).managerBurnCurrentEpoch(holder, tokenId, amount);
+        _roboshareTokenManager().managerBurnCurrentEpoch(holder, tokenId, amount);
     }
 
     function bookSalePenalty(uint256 listingId, address seller, uint256 revenueTokenId, uint256 amount)
@@ -614,6 +614,12 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
             tokenInfo.currentRedemptionBackedPrincipal,
             reason
         );
+    }
+
+    function _roboshareTokenManager() internal view returns (IRoboshareTokenManager manager) {
+        address token = roboshareTokens;
+        if (token.code.length == 0) revert InvalidRoboshareTokens(token);
+        return IRoboshareTokenManager(token);
     }
 
     function _rollRedemptionEpochIfExhausted(TokenLib.TokenInfo storage info) internal {

--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -14,6 +14,14 @@ interface IRoboshareTokenPriceReader {
 
 interface IRoboshareTokenManager {
     function managerBurnCurrentEpoch(address holder, uint256 revenueTokenId, uint256 amount) external;
+
+    function transferLockedForListing(
+        address from,
+        address to,
+        uint256 revenueTokenId,
+        uint256 amount,
+        bytes memory data
+    ) external;
 }
 
 /**
@@ -357,6 +365,16 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         _lockedAmounts[from][revenueTokenId] = lockedAmount - amount;
         emit ListingUnlocked(from, revenueTokenId, amount);
         emit LockedTransferSettled(from, to, revenueTokenId, amount);
+    }
+
+    function transferLockedForListing(address from, address to, uint256 revenueTokenId, uint256 amount)
+        external
+        onlyRole(AUTHORIZED_MARKETPLACE_ROLE)
+    {
+        _requireRevenueToken(revenueTokenId);
+        if (amount == 0) revert InvalidAmount();
+
+        IRoboshareTokenManager(roboshareTokens).transferLockedForListing(from, to, revenueTokenId, amount, "");
     }
 
     function burnCurrentEpochForPrimaryRedemption(address holder, uint256 tokenId, uint256 amount)

--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -46,6 +46,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
     error NotMarketplace();
     error DirectCallNotAllowed();
     error PositionManagerNotSet();
+    error InvalidPositionManager(address manager);
 
     // Events
     event IdBoundToRegistry(uint256 indexed id, address indexed registry);
@@ -479,6 +480,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
     function _positionManager() internal view returns (IPositionManager) {
         IPositionManager manager = roboshareTokens.positionManager();
         if (address(manager) == address(0)) revert PositionManagerNotSet();
+        if (address(manager).code.length == 0) revert InvalidPositionManager(address(manager));
         return manager;
     }
 

--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -42,6 +42,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
     error TreasuryNotSet();
     error EarningsManagerNotSet();
     error MarketplaceNotSet();
+    error InvalidMarketplace(address marketplace);
     error NotTreasury();
     error NotMarketplace();
     error DirectCallNotAllowed();
@@ -243,10 +244,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         (settlementAmount, settlementPerToken) = ITreasury(treasury).initiateSettlement(partner, assetId, topUpAmount);
 
         // Best-effort: settlement should close primary pool if it exists.
-        if (marketplace != address(0)) {
-            uint256 tokenId = TokenLib.getTokenIdFromAssetId(assetId);
-            try IMarketplace(marketplace).closePrimaryPool(tokenId) { } catch { }
-        }
+        _closePrimaryPoolIfMarketplaceConfigured(TokenLib.getTokenIdFromAssetId(assetId));
     }
 
     /**
@@ -270,10 +268,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         (liquidationAmount, settlementPerToken) = ITreasury(treasury).executeLiquidation(assetId);
 
         // Best-effort: liquidation should close primary pool if it exists.
-        if (marketplace != address(0)) {
-            uint256 tokenId = TokenLib.getTokenIdFromAssetId(assetId);
-            try IMarketplace(marketplace).closePrimaryPool(tokenId) { } catch { }
-        }
+        _closePrimaryPoolIfMarketplaceConfigured(TokenLib.getTokenIdFromAssetId(assetId));
     }
 
     /**
@@ -593,7 +588,21 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         emit RevenueTokenPoolCreated(assetId, tokenId, partner, supply * tokenPrice, supply);
         IAssetRegistry(registry).setAssetStatus(assetId, AssetLib.AssetStatus.Active);
 
-        IMarketplace(marketplace).createPrimaryPoolFor(partner, tokenId, tokenPrice);
+        _requireMarketplace().createPrimaryPoolFor(partner, tokenId, tokenPrice);
+    }
+
+    function _requireMarketplace() internal view returns (IMarketplace market) {
+        address marketAddress = marketplace;
+        if (marketAddress == address(0)) revert MarketplaceNotSet();
+        if (marketAddress.code.length == 0) revert InvalidMarketplace(marketAddress);
+        return IMarketplace(marketAddress);
+    }
+
+    function _closePrimaryPoolIfMarketplaceConfigured(uint256 tokenId) internal {
+        address marketAddress = marketplace;
+        if (marketAddress == address(0)) return;
+        if (marketAddress.code.length == 0) revert InvalidMarketplace(marketAddress);
+        try IMarketplace(marketAddress).closePrimaryPool(tokenId) { } catch { }
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }

--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -444,7 +444,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         if (idToRegistry[tokenId] == address(0)) {
             revert RegistryNotFound(tokenId);
         }
-        roboshareTokens.burnCurrentEpochForPrimaryRedemption(holder, tokenId, amount);
+        roboshareTokens.managerBurnCurrentEpoch(holder, tokenId, amount);
     }
 
     function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount) external {

--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -8,6 +8,7 @@ import { IAssetRegistry } from "./interfaces/IAssetRegistry.sol";
 import { IEarningsManager } from "./interfaces/IEarningsManager.sol";
 import { ITreasury } from "./interfaces/ITreasury.sol";
 import { IMarketplace } from "./interfaces/IMarketplace.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
 import { AssetLib, TokenLib } from "./Libraries.sol";
 import { RoboshareTokens } from "./RoboshareTokens.sol";
 import { PartnerManager } from "./PartnerManager.sol";
@@ -444,7 +445,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         if (idToRegistry[tokenId] == address(0)) {
             revert RegistryNotFound(tokenId);
         }
-        roboshareTokens.managerBurnCurrentEpoch(holder, tokenId, amount);
+        _positionManager().burnCurrentEpochForPrimaryRedemption(holder, tokenId, amount);
     }
 
     function recordImmediateProceedsRelease(uint256 tokenId, uint256 releasedAmount) external {
@@ -457,7 +458,8 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         if (idToRegistry[tokenId] == address(0)) {
             revert RegistryNotFound(tokenId);
         }
-        roboshareTokens.recordImmediateProceedsRelease(tokenId, releasedAmount);
+        _positionManager()
+            .recordImmediateProceedsRelease(tokenId, releasedAmount, keccak256("IMMEDIATE_PROCEEDS_RELEASE"));
     }
 
     function recordPrimaryRedemptionPayout(uint256 tokenId, uint256 payoutAmount) external {
@@ -470,7 +472,11 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         if (idToRegistry[tokenId] == address(0)) {
             revert RegistryNotFound(tokenId);
         }
-        roboshareTokens.recordPrimaryRedemptionPayout(tokenId, payoutAmount);
+        _positionManager().recordPrimaryRedemptionPayout(tokenId, payoutAmount, keccak256("PRIMARY_REDEMPTION_PAYOUT"));
+    }
+
+    function _positionManager() internal view returns (IPositionManager) {
+        return roboshareTokens.positionManager();
     }
 
     function getRegistryForAsset(uint256 assetId) external view override returns (address) {

--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -45,6 +45,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
     error NotTreasury();
     error NotMarketplace();
     error DirectCallNotAllowed();
+    error PositionManagerNotSet();
 
     // Events
     event IdBoundToRegistry(uint256 indexed id, address indexed registry);
@@ -476,7 +477,9 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
     }
 
     function _positionManager() internal view returns (IPositionManager) {
-        return roboshareTokens.positionManager();
+        IPositionManager manager = roboshareTokens.positionManager();
+        if (address(manager) == address(0)) revert PositionManagerNotSet();
+        return manager;
     }
 
     function getRegistryForAsset(uint256 assetId) external view override returns (address) {

--- a/protocols/evm/contracts/RoboshareTokens.sol
+++ b/protocols/evm/contracts/RoboshareTokens.sol
@@ -88,7 +88,6 @@ contract RoboshareTokens is
         _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
         _grantRole(MINTER_ROLE, defaultAdmin);
         _grantRole(BURNER_ROLE, defaultAdmin);
-        _grantRole(MANAGER_ROLE, defaultAdmin);
         _grantRole(URI_SETTER_ROLE, defaultAdmin);
         _grantRole(UPGRADER_ROLE, defaultAdmin);
         _grantRole(AUTHORIZED_CONTRACT_ROLE, defaultAdmin);
@@ -240,7 +239,12 @@ contract RoboshareTokens is
         _syncRevenueTokenPolicies(manager);
 
         address previousManager = address(positionManager);
+        if (previousManager != address(0)) {
+            _revokeRole(MANAGER_ROLE, previousManager);
+        }
+
         positionManager = manager;
+        _grantRole(MANAGER_ROLE, newPositionManager);
 
         emit PositionManagerUpdated(previousManager, newPositionManager);
     }

--- a/protocols/evm/contracts/RoboshareTokens.sol
+++ b/protocols/evm/contracts/RoboshareTokens.sol
@@ -27,6 +27,7 @@ contract RoboshareTokens is
     bytes32 public constant URI_SETTER_ROLE = keccak256("URI_SETTER_ROLE");
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
     bytes32 public constant AUTHORIZED_CONTRACT_ROLE = keccak256("AUTHORIZED_CONTRACT_ROLE");
 
     // Errors
@@ -87,6 +88,7 @@ contract RoboshareTokens is
         _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
         _grantRole(MINTER_ROLE, defaultAdmin);
         _grantRole(BURNER_ROLE, defaultAdmin);
+        _grantRole(MANAGER_ROLE, defaultAdmin);
         _grantRole(URI_SETTER_ROLE, defaultAdmin);
         _grantRole(UPGRADER_ROLE, defaultAdmin);
         _grantRole(AUTHORIZED_CONTRACT_ROLE, defaultAdmin);
@@ -197,6 +199,30 @@ contract RoboshareTokens is
      */
     function burnBatch(address from, uint256[] memory ids, uint256[] memory amounts) external onlyRole(BURNER_ROLE) {
         _burnBatch(from, ids, amounts);
+    }
+
+    function managerTransfer(address from, address to, uint256 id, uint256 amount, bytes memory data)
+        external
+        onlyRole(MANAGER_ROLE)
+    {
+        if (!TokenLib.isRevenueToken(id)) {
+            revert NotRevenueToken();
+        }
+        _safeTransferFrom(from, to, id, amount, data);
+    }
+
+    function managerBurn(address from, uint256 id, uint256 amount) external onlyRole(MANAGER_ROLE) {
+        if (!TokenLib.isRevenueToken(id)) {
+            revert NotRevenueToken();
+        }
+        _burn(from, id, amount);
+    }
+
+    function managerBurnCurrentEpoch(address holder, uint256 revenueTokenId, uint256 amount)
+        external
+        onlyRole(MANAGER_ROLE)
+    {
+        _managerBurnCurrentEpoch(holder, revenueTokenId, amount);
     }
 
     /**
@@ -349,10 +375,7 @@ contract RoboshareTokens is
         return _requirePositionManager().getLockedAmount(holder, revenueTokenId);
     }
 
-    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount)
-        external
-        onlyRole(AUTHORIZED_CONTRACT_ROLE)
-    {
+    function lockForListing(address holder, uint256 revenueTokenId, uint256 amount) external onlyRole(MANAGER_ROLE) {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
@@ -360,10 +383,7 @@ contract RoboshareTokens is
         _requirePositionManager().lockForListing(holder, revenueTokenId, amount);
     }
 
-    function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount)
-        external
-        onlyRole(AUTHORIZED_CONTRACT_ROLE)
-    {
+    function unlockForListing(address holder, uint256 revenueTokenId, uint256 amount) external onlyRole(MANAGER_ROLE) {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
@@ -371,10 +391,17 @@ contract RoboshareTokens is
         _requirePositionManager().unlockForListing(holder, revenueTokenId, amount);
     }
 
+    /**
+     * @dev Deprecated compatibility alias for managerBurnCurrentEpoch().
+     */
     function burnCurrentEpochForPrimaryRedemption(address holder, uint256 revenueTokenId, uint256 amount)
         external
-        onlyRole(BURNER_ROLE)
+        onlyRole(MANAGER_ROLE)
     {
+        _managerBurnCurrentEpoch(holder, revenueTokenId, amount);
+    }
+
+    function _managerBurnCurrentEpoch(address holder, uint256 revenueTokenId, uint256 amount) internal {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }
@@ -385,7 +412,7 @@ contract RoboshareTokens is
 
     function recordImmediateProceedsRelease(uint256 revenueTokenId, uint256 releasedAmount)
         external
-        onlyRole(BURNER_ROLE)
+        onlyRole(MANAGER_ROLE)
     {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
@@ -397,7 +424,7 @@ contract RoboshareTokens is
 
     function recordPrimaryRedemptionPayout(uint256 revenueTokenId, uint256 payoutAmount)
         external
-        onlyRole(BURNER_ROLE)
+        onlyRole(MANAGER_ROLE)
     {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
@@ -413,7 +440,7 @@ contract RoboshareTokens is
         uint256 revenueTokenId,
         uint256 amount,
         bytes memory data
-    ) external onlyRole(AUTHORIZED_CONTRACT_ROLE) {
+    ) external onlyRole(MANAGER_ROLE) {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
         }

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -133,6 +133,7 @@ interface IPositionManager {
     error SettlementNotConfigured(uint256 assetId);
     error UnauthorizedTokenHookCaller(address caller);
     error UnsupportedPositionMutation(PositionMutationType mutationType);
+    error InvalidRoboshareTokens(address token);
 
     function initialize(
         address admin,

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -194,6 +194,8 @@ interface IPositionManager {
 
     function settleLockedTransfer(address from, address to, uint256 revenueTokenId, uint256 amount) external;
 
+    function burnCurrentEpochForPrimaryRedemption(address holder, uint256 tokenId, uint256 amount) external;
+
     function bookSalePenalty(uint256 listingId, address seller, uint256 revenueTokenId, uint256 amount) external;
 
     function clearSalePenalty(uint256 listingId) external;

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -194,6 +194,8 @@ interface IPositionManager {
 
     function settleLockedTransfer(address from, address to, uint256 revenueTokenId, uint256 amount) external;
 
+    function transferLockedForListing(address from, address to, uint256 revenueTokenId, uint256 amount) external;
+
     function burnCurrentEpochForPrimaryRedemption(address holder, uint256 tokenId, uint256 amount) external;
 
     function bookSalePenalty(uint256 listingId, address seller, uint256 revenueTokenId, uint256 amount) external;

--- a/protocols/evm/script/DeployCore.s.sol
+++ b/protocols/evm/script/DeployCore.s.sol
@@ -154,8 +154,8 @@ abstract contract DeployCore is ScaffoldETHDeploy {
 
         // Grant BURNER_ROLE to VehicleRegistry (for burning revenue tokens on retirement)
         contracts.roboshareTokens.grantRole(contracts.roboshareTokens.BURNER_ROLE(), address(contracts.vehicleRegistry));
-        contracts.roboshareTokens
-            .grantRole(contracts.roboshareTokens.AUTHORIZED_CONTRACT_ROLE(), address(contracts.marketplace));
+        contracts.roboshareTokens.grantRole(contracts.roboshareTokens.MANAGER_ROLE(), address(contracts.router));
+        contracts.roboshareTokens.grantRole(contracts.roboshareTokens.MANAGER_ROLE(), address(contracts.marketplace));
 
         // Grant AUTHORIZED_MARKETPLACE_ROLE to Marketplace on Treasury for purchase/redemption settlement flows
         contracts.treasury.grantRole(contracts.treasury.AUTHORIZED_MARKETPLACE_ROLE(), address(contracts.marketplace));

--- a/protocols/evm/script/DeployCore.s.sol
+++ b/protocols/evm/script/DeployCore.s.sol
@@ -154,8 +154,6 @@ abstract contract DeployCore is ScaffoldETHDeploy {
 
         // Grant BURNER_ROLE to VehicleRegistry (for burning revenue tokens on retirement)
         contracts.roboshareTokens.grantRole(contracts.roboshareTokens.BURNER_ROLE(), address(contracts.vehicleRegistry));
-        // Grant BURNER_ROLE to Router (for primary-redemption burns routed via RegistryRouter)
-        contracts.roboshareTokens.grantRole(contracts.roboshareTokens.BURNER_ROLE(), address(contracts.router));
         contracts.roboshareTokens
             .grantRole(contracts.roboshareTokens.AUTHORIZED_CONTRACT_ROLE(), address(contracts.marketplace));
 

--- a/protocols/evm/script/DeployCore.s.sol
+++ b/protocols/evm/script/DeployCore.s.sol
@@ -154,8 +154,6 @@ abstract contract DeployCore is ScaffoldETHDeploy {
 
         // Grant BURNER_ROLE to VehicleRegistry (for burning revenue tokens on retirement)
         contracts.roboshareTokens.grantRole(contracts.roboshareTokens.BURNER_ROLE(), address(contracts.vehicleRegistry));
-        contracts.roboshareTokens.grantRole(contracts.roboshareTokens.MANAGER_ROLE(), address(contracts.router));
-        contracts.roboshareTokens.grantRole(contracts.roboshareTokens.MANAGER_ROLE(), address(contracts.marketplace));
 
         // Grant AUTHORIZED_MARKETPLACE_ROLE to Marketplace on Treasury for purchase/redemption settlement flows
         contracts.treasury.grantRole(contracts.treasury.AUTHORIZED_MARKETPLACE_ROLE(), address(contracts.marketplace));

--- a/protocols/evm/script/UpgradeRegistryRouter.s.sol
+++ b/protocols/evm/script/UpgradeRegistryRouter.s.sol
@@ -13,8 +13,10 @@ contract UpgradeRegistryRouter is ScaffoldETHDeploy {
     function run() external scaffoldEthDeployerRunner {
         // Get proxy address from environment variable (set by parseArgs.js)
         address proxyAddress = vm.envAddress("PROXY_ADDRESS");
+        bool confirmSplitUpgrade = vm.envBool("CONFIRM_POSITION_MANAGER_SPLIT_UPGRADE");
 
         require(proxyAddress != address(0), "Proxy address cannot be zero");
+        require(confirmSplitUpgrade, "CONFIRM_POSITION_MANAGER_SPLIT_UPGRADE=true required");
 
         console.log("=== RegistryRouter Upgrade ===");
         console.log("RegistryRouter proxy:", proxyAddress);
@@ -34,11 +36,16 @@ contract UpgradeRegistryRouter is ScaffoldETHDeploy {
         console.log("New implementation address:", address(newImplementation));
         console.log("RegistryRouter upgrade completed successfully!");
         console.log("");
-        console.log("Note: Run any necessary admin functions for this upgrade manually or via script.");
+        console.log("Note: This is part of the PositionManager split rollout.");
+        console.log("Upgrade RoboshareTokens and PositionManager, then complete MANAGER_ROLE wiring before Router.");
+        console.log("Run any remaining admin or deployment steps manually or via script.");
     }
 
     function help() external pure {
-        console.log("Usage: yarn upgrade --contract RegistryRouter --proxy-address <addr>");
-        console.log("Post-upgrade: Configure via admin functions");
+        console.log(
+            "Usage: CONFIRM_POSITION_MANAGER_SPLIT_UPGRADE=true yarn upgrade --contract RegistryRouter --proxy-address <addr>"
+        );
+        console.log("Precondition: RoboshareTokens and PositionManager upgrades/wiring completed first.");
+        console.log("Post-upgrade: Complete any remaining admin functions");
     }
 }

--- a/protocols/evm/script/UpgradeRoboshareTokens.s.sol
+++ b/protocols/evm/script/UpgradeRoboshareTokens.s.sol
@@ -34,11 +34,13 @@ contract UpgradeRoboshareTokens is ScaffoldETHDeploy {
         console.log("New implementation address:", address(newImplementation));
         console.log("RoboshareTokens upgrade completed successfully!");
         console.log("");
-        console.log("Note: Run any necessary admin functions for this upgrade manually or via script.");
+        console.log("Note: This upgrade is part of the PositionManager split rollout.");
+        console.log("PositionManager must hold MANAGER_ROLE before Router starts using the new manager-gated paths.");
+        console.log("Complete coordinated admin wiring and Router upgrade steps manually or via script.");
     }
 
     function help() external pure {
         console.log("Usage: yarn upgrade --contract RoboshareTokens --proxy-address <addr>");
-        console.log("Post-upgrade: Configure via admin functions");
+        console.log("Post-upgrade: attach PositionManager and complete MANAGER_ROLE/admin wiring before Router upgrade");
     }
 }

--- a/protocols/evm/test/integration/Marketplace.Integration.t.sol
+++ b/protocols/evm/test/integration/Marketplace.Integration.t.sol
@@ -952,6 +952,27 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
         assertEq(roboshareTokens.getLockedAmount(partner1, scenario.revenueTokenId), 0);
     }
 
+    function testBuyFromSecondaryListingAfterSellerRevokesMarketplaceApproval() public {
+        _ensureSecondaryListingScenario();
+
+        vm.prank(partner1);
+        roboshareTokens.setApprovalForAll(address(marketplace), false);
+
+        uint256 totalPrice = SECONDARY_PURCHASE_AMOUNT * REVENUE_TOKEN_PRICE;
+        uint256 protocolFee = ProtocolLib.calculateProtocolFee(totalPrice);
+
+        vm.startPrank(buyer);
+        usdc.approve(address(marketplace), totalPrice + protocolFee);
+        marketplace.buyFromSecondaryListing(scenario.listingId, SECONDARY_PURCHASE_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), SECONDARY_PURCHASE_AMOUNT);
+        assertEq(
+            roboshareTokens.getLockedAmount(partner1, scenario.revenueTokenId),
+            SECONDARY_LISTING_AMOUNT - SECONDARY_PURCHASE_AMOUNT
+        );
+    }
+
     function testBuyFromSecondaryListingInsufficientPayment() public {
         _ensureSecondaryListingScenario();
 

--- a/protocols/evm/test/unit/Marketplace.t.sol
+++ b/protocols/evm/test/unit/Marketplace.t.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.19;
 
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { BaseTest } from "../base/BaseTest.t.sol";
+import { AssetMetadataBaseTest } from "../base/AssetMetadataBaseTest.t.sol";
 import { MockUSDC } from "../../contracts/mocks/MockUSDC.sol";
 import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
 import { PartnerManager } from "../../contracts/PartnerManager.sol";
 import { RegistryRouter } from "../../contracts/RegistryRouter.sol";
 import { Treasury } from "../../contracts/Treasury.sol";
 import { Marketplace } from "../../contracts/Marketplace.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 
 contract MarketplaceBadTotalSupplyToken {
     function totalSupply() external pure returns (uint256) {
@@ -51,17 +52,46 @@ contract MarketplaceInternalHarness is Marketplace {
     }
 }
 
-contract MarketplaceTest is BaseTest {
-    function _setupAssetRegistered() internal view override returns (uint256) {
-        return scenario.assetId;
+contract MarketplaceRoboshareTokensStub {
+    IPositionManager internal _positionManager;
+    uint256 internal _supply;
+    uint256 internal _penalty;
+    mapping(address => mapping(uint256 => uint256)) internal _balances;
+
+    function setPositionManager(address manager) external {
+        _positionManager = IPositionManager(manager);
     }
 
-    function _setupPrimaryPoolCreated() internal view override returns (uint256) {
-        return scenario.revenueTokenId;
+    function setRevenueTokenSupply(uint256 supply) external {
+        _supply = supply;
     }
 
-    function _setupPurchasedFromPrimaryPool() internal override { }
+    function setSalesPenalty(uint256 penalty) external {
+        _penalty = penalty;
+    }
 
+    function setBalance(address holder, uint256 tokenId, uint256 amount) external {
+        _balances[holder][tokenId] = amount;
+    }
+
+    function positionManager() external view returns (IPositionManager) {
+        return _positionManager;
+    }
+
+    function getRevenueTokenSupply(uint256) external view returns (uint256) {
+        return _supply;
+    }
+
+    function balanceOf(address holder, uint256 tokenId) external view returns (uint256) {
+        return _balances[holder][tokenId];
+    }
+
+    function getSalesPenalty(address, uint256, uint256) external view returns (uint256) {
+        return _penalty;
+    }
+}
+
+contract MarketplaceTest is AssetMetadataBaseTest {
     function _setupBuffersFunded() internal override { }
 
     function _setupEarningsDistributed(uint256) internal override { }
@@ -341,6 +371,69 @@ contract MarketplaceTest is BaseTest {
         );
         vm.prank(unauthorized);
         marketplace.updateRoboshareTokens(address(newRoboshareTokens));
+    }
+
+    function testCreateListingRevertsWhenPositionManagerUnset() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        MarketplaceRoboshareTokensStub stub = new MarketplaceRoboshareTokensStub();
+        stub.setRevenueTokenSupply(SECONDARY_LISTING_AMOUNT);
+        stub.setBalance(partner1, scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT);
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(stub));
+
+        vm.prank(partner1);
+        vm.expectRevert(Marketplace.PositionManagerNotSet.selector);
+        marketplace.createListing(
+            scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT, REVENUE_TOKEN_PRICE, LISTING_DURATION, true
+        );
+    }
+
+    function testCreateListingRevertsWhenPositionManagerIsNotContract() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        MarketplaceRoboshareTokensStub stub = new MarketplaceRoboshareTokensStub();
+        stub.setPositionManager(unauthorized);
+        stub.setRevenueTokenSupply(SECONDARY_LISTING_AMOUNT);
+        stub.setBalance(partner1, scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT);
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(stub));
+
+        vm.prank(partner1);
+        vm.expectRevert(abi.encodeWithSelector(Marketplace.InvalidPositionManager.selector, unauthorized));
+        marketplace.createListing(
+            scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT, REVENUE_TOKEN_PRICE, LISTING_DURATION, true
+        );
+    }
+
+    function testBuyFromSecondaryListingRevertsWhenPositionManagerIsNotContract() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+        _purchasePrimaryPoolTokens(partner1, scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT);
+
+        vm.prank(partner1);
+        uint256 listingId = marketplace.createListing(
+            scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT, REVENUE_TOKEN_PRICE, LISTING_DURATION, true
+        );
+
+        MarketplaceRoboshareTokensStub stub = new MarketplaceRoboshareTokensStub();
+        stub.setPositionManager(unauthorized);
+        stub.setSalesPenalty(0);
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(stub));
+
+        uint256 buyerUsdcBefore = usdc.balanceOf(buyer);
+        (,, uint256 expectedPayment) = marketplace.previewSecondaryPurchase(listingId, SECONDARY_PURCHASE_AMOUNT);
+
+        vm.startPrank(buyer);
+        usdc.approve(address(marketplace), expectedPayment);
+        vm.expectRevert(abi.encodeWithSelector(Marketplace.InvalidPositionManager.selector, unauthorized));
+        marketplace.buyFromSecondaryListing(listingId, SECONDARY_PURCHASE_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(usdc.balanceOf(buyer), buyerUsdcBefore);
     }
 
     function testUpdateTreasury() public {

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -376,6 +376,30 @@ contract PositionManagerTest is Test {
         positionManager.settleLockedTransfer(alice, bob, TOKEN_ID, 0);
     }
 
+    function testAuthorizedMarketplaceCanTransferLockedForListingViaTokenManager() public {
+        vm.expectCall(
+            roboshareTokens,
+            abi.encodeWithSignature(
+                "transferLockedForListing(address,address,uint256,uint256,bytes)", alice, bob, TOKEN_ID, 20, ""
+            )
+        );
+
+        vm.prank(marketplace);
+        positionManager.transferLockedForListing(alice, bob, TOKEN_ID, 20);
+    }
+
+    function testTransferLockedForListingUnauthorizedCaller() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                unauthorized,
+                positionManager.AUTHORIZED_MARKETPLACE_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        positionManager.transferLockedForListing(alice, bob, TOKEN_ID, 20);
+    }
+
     function testAuthorizedRouterCanBurnCurrentEpochForPrimaryRedemption() public {
         vm.expectCall(
             roboshareTokens,

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -91,6 +91,7 @@ contract PositionManagerTest is Test {
     );
 
     function setUp() public {
+        vm.etch(roboshareTokens, hex"00");
         positionManager =
             _deployPositionManager(admin, registryRouter, roboshareTokens, partnerManager, marketplace, treasury, usdc);
         _mockTokenPrice(TOKEN_ID, TOKEN_PRICE);
@@ -400,6 +401,15 @@ contract PositionManagerTest is Test {
         positionManager.transferLockedForListing(alice, bob, TOKEN_ID, 20);
     }
 
+    function testTransferLockedForListingRevertsWhenRoboshareTokensIsNotContract() public {
+        vm.prank(admin);
+        positionManager.updateRoboshareTokens(unauthorized);
+
+        vm.prank(marketplace);
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.InvalidRoboshareTokens.selector, unauthorized));
+        positionManager.transferLockedForListing(alice, bob, TOKEN_ID, 20);
+    }
+
     function testAuthorizedRouterCanBurnCurrentEpochForPrimaryRedemption() public {
         vm.expectCall(
             roboshareTokens,
@@ -425,6 +435,15 @@ contract PositionManagerTest is Test {
             )
         );
         vm.prank(unauthorized);
+        positionManager.burnCurrentEpochForPrimaryRedemption(alice, TOKEN_ID, 10);
+    }
+
+    function testBurnCurrentEpochForPrimaryRedemptionRevertsWhenRoboshareTokensIsNotContract() public {
+        vm.prank(admin);
+        positionManager.updateRoboshareTokens(unauthorized);
+
+        vm.prank(registryRouter);
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.InvalidRoboshareTokens.selector, unauthorized));
         positionManager.burnCurrentEpochForPrimaryRedemption(alice, TOKEN_ID, 10);
     }
 

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -305,6 +305,12 @@ contract PositionManagerTest is Test {
         assertEq(positionManager.getAvailableAmount(alice, TOKEN_ID, 100), 60);
     }
 
+    function testLockForListingRevertsWhenAmountIsZero() public {
+        vm.expectRevert(IPositionManager.InvalidAmount.selector);
+        vm.prank(marketplace);
+        positionManager.lockForListing(alice, TOKEN_ID, 0);
+    }
+
     function testLockForListingRevertsWhenUnlockedBalanceInsufficient() public {
         _mockRevenueTokenBalance(alice, TOKEN_ID, 100);
 
@@ -328,6 +334,12 @@ contract PositionManagerTest is Test {
         vm.expectRevert(IPositionManager.InsufficientLockedBalance.selector);
         vm.prank(marketplace);
         positionManager.unlockForListing(alice, TOKEN_ID, 1);
+    }
+
+    function testUnlockForListingRevertsWhenAmountIsZero() public {
+        vm.expectRevert(IPositionManager.InvalidAmount.selector);
+        vm.prank(marketplace);
+        positionManager.unlockForListing(alice, TOKEN_ID, 0);
     }
 
     function testSettleLockedTransferConsumesLockBeforeTokenMove() public {
@@ -356,6 +368,40 @@ contract PositionManagerTest is Test {
         vm.expectRevert(IPositionManager.InsufficientLockedBalance.selector);
         vm.prank(marketplace);
         positionManager.settleLockedTransfer(alice, bob, TOKEN_ID, 11);
+    }
+
+    function testSettleLockedTransferRevertsWhenAmountIsZero() public {
+        vm.expectRevert(IPositionManager.InvalidAmount.selector);
+        vm.prank(marketplace);
+        positionManager.settleLockedTransfer(alice, bob, TOKEN_ID, 0);
+    }
+
+    function testAuthorizedRouterCanBurnCurrentEpochForPrimaryRedemption() public {
+        vm.expectCall(
+            roboshareTokens,
+            abi.encodeWithSignature("managerBurnCurrentEpoch(address,uint256,uint256)", alice, TOKEN_ID, 10)
+        );
+
+        vm.prank(registryRouter);
+        positionManager.burnCurrentEpochForPrimaryRedemption(alice, TOKEN_ID, 10);
+    }
+
+    function testBurnCurrentEpochForPrimaryRedemptionRevertsWhenAmountIsZero() public {
+        vm.expectRevert(IPositionManager.InvalidAmount.selector);
+        vm.prank(registryRouter);
+        positionManager.burnCurrentEpochForPrimaryRedemption(alice, TOKEN_ID, 0);
+    }
+
+    function testBurnCurrentEpochForPrimaryRedemptionUnauthorizedCaller() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                unauthorized,
+                positionManager.AUTHORIZED_ROUTER_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        positionManager.burnCurrentEpochForPrimaryRedemption(alice, TOKEN_ID, 10);
     }
 
     function testSalesPenaltyBookkeeping() public {
@@ -528,6 +574,32 @@ contract PositionManagerTest is Test {
         assertEq(positionManager.getCurrentPrimaryRedemptionEpoch(TOKEN_ID), 0);
         assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 100);
         assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 60 * TOKEN_PRICE);
+    }
+
+    function testAuthorizedRouterCanRecordImmediateProceedsRelease() public {
+        vm.prank(marketplace);
+        positionManager.recordPositionMutation(
+            IPositionManager.PositionMutation({
+                assetId: ASSET_ID,
+                tokenId: TOKEN_ID,
+                account: alice,
+                amount: 100,
+                auxValue: 0,
+                mutationType: IPositionManager.PositionMutationType.Mint,
+                reason: PRIMARY_REASON
+            })
+        );
+
+        vm.prank(registryRouter);
+        positionManager.recordImmediateProceedsRelease(TOKEN_ID, 25 * TOKEN_PRICE, REDEEM_REASON);
+
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 75 * TOKEN_PRICE);
+    }
+
+    function testUnauthorizedCallerCannotRecordImmediateProceedsRelease() public {
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.UnauthorizedTokenHookCaller.selector, unauthorized));
+        vm.prank(unauthorized);
+        positionManager.recordImmediateProceedsRelease(TOKEN_ID, TOKEN_PRICE, REDEEM_REASON);
     }
 
     function testSettlementStateTracksClaimTotals() public {

--- a/protocols/evm/test/unit/RegistryRouter.t.sol
+++ b/protocols/evm/test/unit/RegistryRouter.t.sol
@@ -6,6 +6,7 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { AssetMetadataBaseTest } from "../base/AssetMetadataBaseTest.t.sol";
 import { AssetLib } from "../../contracts/Libraries.sol";
 import { RegistryRouter } from "../../contracts/RegistryRouter.sol";
+import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
 
 contract RegistryRouterTest is AssetMetadataBaseTest {
     function _setupBuffersFunded() internal override { }
@@ -241,6 +242,23 @@ contract RegistryRouterTest is AssetMetadataBaseTest {
         vm.prank(address(treasury));
         vm.expectRevert(abi.encodeWithSelector(RegistryRouter.RegistryNotFound.selector, tokenIdWithoutRegistry));
         router.recordImmediateProceedsRelease(tokenIdWithoutRegistry, 1);
+    }
+
+    function testRecordImmediateProceedsReleaseRevertsWhenPositionManagerUnset() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        RoboshareTokens freshToken = RoboshareTokens(
+            address(
+                new ERC1967Proxy(address(new RoboshareTokens()), abi.encodeWithSignature("initialize(address)", admin))
+            )
+        );
+
+        vm.prank(admin);
+        router.updateRoboshareTokens(address(freshToken));
+
+        vm.prank(address(treasury));
+        vm.expectRevert(RegistryRouter.PositionManagerNotSet.selector);
+        router.recordImmediateProceedsRelease(scenario.revenueTokenId, 1);
     }
 
     function testRecordPrimaryRedemptionPayoutNotTreasury() public {

--- a/protocols/evm/test/unit/RegistryRouter.t.sol
+++ b/protocols/evm/test/unit/RegistryRouter.t.sol
@@ -261,6 +261,26 @@ contract RegistryRouterTest is AssetMetadataBaseTest {
         router.recordImmediateProceedsRelease(scenario.revenueTokenId, 1);
     }
 
+    function testCreateRevenueTokenPoolRevertsWhenMarketplaceIsNotContract() public {
+        _ensureState(SetupState.AssetRegistered);
+
+        vm.prank(admin);
+        router.setMarketplace(unauthorized);
+
+        vm.prank(partner1);
+        vm.expectRevert(abi.encodeWithSelector(RegistryRouter.InvalidMarketplace.selector, unauthorized));
+        assetRegistry.createRevenueTokenPool(
+            scenario.assetId,
+            REVENUE_TOKEN_PRICE,
+            block.timestamp + 365 days,
+            10_000,
+            1_000,
+            ASSET_VALUE / REVENUE_TOKEN_PRICE,
+            false,
+            false
+        );
+    }
+
     function testBurnRevenueTokensFromHolderForPrimaryRedemptionRevertsWhenPositionManagerIsNotContract() public {
         _ensureState(SetupState.PrimaryPoolCreated);
 

--- a/protocols/evm/test/unit/RegistryRouter.t.sol
+++ b/protocols/evm/test/unit/RegistryRouter.t.sol
@@ -261,6 +261,26 @@ contract RegistryRouterTest is AssetMetadataBaseTest {
         router.recordImmediateProceedsRelease(scenario.revenueTokenId, 1);
     }
 
+    function testBurnRevenueTokensFromHolderForPrimaryRedemptionRevertsWhenPositionManagerIsNotContract() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        RoboshareTokens freshToken = RoboshareTokens(
+            address(
+                new ERC1967Proxy(address(new RoboshareTokens()), abi.encodeWithSignature("initialize(address)", admin))
+            )
+        );
+
+        vm.prank(admin);
+        freshToken.setPositionManager(unauthorized);
+
+        vm.prank(admin);
+        router.updateRoboshareTokens(address(freshToken));
+
+        vm.prank(address(treasury));
+        vm.expectRevert(abi.encodeWithSelector(RegistryRouter.InvalidPositionManager.selector, unauthorized));
+        router.burnRevenueTokensFromHolderForPrimaryRedemption(buyer, scenario.revenueTokenId, 1);
+    }
+
     function testRecordPrimaryRedemptionPayoutNotTreasury() public {
         vm.expectRevert(RegistryRouter.NotTreasury.selector);
         router.recordPrimaryRedemptionPayout(102, 1);

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -78,6 +78,7 @@ contract MockPositionManager {
 contract RoboshareTokensTest is AssetMetadataBaseTest {
     address public minter;
     address public burner;
+    address public manager;
     address public user1 = makeAddr("user1");
     address public user2 = makeAddr("user2");
     PositionManager public testPositionManager;
@@ -93,6 +94,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.setPositionManager(address(testPositionManager));
         minter = admin; // Admin has minter role by default
         burner = admin; // Admin has burner role by default
+        manager = admin; // Admin has manager role by default
 
         // These helpers run against a fork in CI/local workflows, so ensure the
         // deterministic test users are EOAs even if the forked chain has code there.
@@ -156,10 +158,12 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         assertTrue(roboshareTokens.hasRole(roboshareTokens.UPGRADER_ROLE(), admin));
         assertTrue(roboshareTokens.hasRole(roboshareTokens.MINTER_ROLE(), admin));
         assertTrue(roboshareTokens.hasRole(roboshareTokens.MINTER_ROLE(), minter));
+        assertTrue(roboshareTokens.hasRole(roboshareTokens.MANAGER_ROLE(), admin));
 
         // Verify role hashes
         assertEq(roboshareTokens.MINTER_ROLE(), keccak256("MINTER_ROLE"), "Invalid MINTER_ROLE hash");
         assertEq(roboshareTokens.BURNER_ROLE(), keccak256("BURNER_ROLE"), "Invalid BURNER_ROLE hash");
+        assertEq(roboshareTokens.MANAGER_ROLE(), keccak256("MANAGER_ROLE"), "Invalid MANAGER_ROLE hash");
         assertEq(roboshareTokens.URI_SETTER_ROLE(), keccak256("URI_SETTER_ROLE"), "Invalid URI_SETTER_ROLE hash");
         assertEq(roboshareTokens.UPGRADER_ROLE(), keccak256("UPGRADER_ROLE"), "Invalid UPGRADER_ROLE hash");
     }
@@ -349,6 +353,69 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.setURI("ipfs://new-uri");
     }
 
+    function testManagerTransferUnauthorizedCaller() public {
+        vm.prank(minter);
+        roboshareTokens.mint(user1, 101, 100, "");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, unauthorized, roboshareTokens.MANAGER_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        roboshareTokens.managerTransfer(user1, user2, 101, 10, "");
+    }
+
+    function testManagerTransferMovesTokens() public {
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        vm.prank(manager);
+        roboshareTokens.managerTransfer(user1, user2, tokenId, 10, "");
+
+        assertEq(roboshareTokens.balanceOf(user1, tokenId), 90);
+        assertEq(roboshareTokens.balanceOf(user2, tokenId), 10);
+    }
+
+    function testManagerBurnUnauthorizedCaller() public {
+        vm.prank(minter);
+        roboshareTokens.mint(user1, 101, 100, "");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, unauthorized, roboshareTokens.MANAGER_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        roboshareTokens.managerBurn(user1, 101, 10);
+    }
+
+    function testManagerBurnBurnsTokens() public {
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        vm.prank(manager);
+        roboshareTokens.managerBurn(user1, tokenId, 10);
+
+        assertEq(roboshareTokens.balanceOf(user1, tokenId), 90);
+    }
+
+    function testManagerTransferNotRevenueToken() public {
+        vm.prank(minter);
+        roboshareTokens.mint(user1, 101, 100, "");
+
+        vm.prank(manager);
+        vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
+        roboshareTokens.managerTransfer(user1, user2, 101, 10, "");
+    }
+
+    function testManagerBurnNotRevenueToken() public {
+        vm.prank(minter);
+        roboshareTokens.mint(user1, 101, 100, "");
+
+        vm.prank(manager);
+        vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
+        roboshareTokens.managerBurn(user1, 101, 10);
+    }
+
     function testRevenueTokenMintCallsPositionManagerHook() public {
         MockPositionManager mockManager = new MockPositionManager();
 
@@ -501,14 +568,14 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     }
 
     function testLockForListingNotRevenueToken() public {
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
         roboshareTokens.lockForListing(user1, 101, 1);
     }
 
     function testLockForListingZeroAmount() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InvalidLockAmount.selector);
         roboshareTokens.lockForListing(user1, tokenId, 0);
     }
@@ -516,10 +583,10 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     function testLockForListingInsufficientUnlockedBalance() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
 
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, 80);
 
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InsufficientUnlockedBalance.selector);
         roboshareTokens.lockForListing(user1, tokenId, 30);
     }
@@ -527,51 +594,51 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     function testLockForListingAndGetLockedAmount() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
 
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, 25);
 
         assertEq(roboshareTokens.getLockedAmount(user1, tokenId), 25);
     }
 
     function testUnlockForListingNotRevenueToken() public {
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
         roboshareTokens.unlockForListing(user1, 101, 1);
     }
 
     function testUnlockForListingZeroAmount() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, 10);
 
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InvalidLockAmount.selector);
         roboshareTokens.unlockForListing(user1, tokenId, 0);
     }
 
     function testUnlockForListingInsufficientLockedBalance() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InsufficientLockedBalance.selector);
         roboshareTokens.unlockForListing(user1, tokenId, 1);
     }
 
     function testTransferLockedForListingNotRevenueToken() public {
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
         roboshareTokens.transferLockedForListing(user1, user2, 101, 1, "");
     }
 
     function testTransferLockedForListingZeroAmount() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InvalidLockAmount.selector);
         roboshareTokens.transferLockedForListing(user1, user2, tokenId, 0, "");
     }
 
     function testTransferLockedForListingInsufficientLockedBalance() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InsufficientLockedBalance.selector);
         roboshareTokens.transferLockedForListing(user1, user2, tokenId, 1, "");
     }
@@ -579,11 +646,11 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     function testTransferLockedForListingMovesTokensAndUnlocks() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
 
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, 40);
         assertEq(roboshareTokens.getLockedAmount(user1, tokenId), 40);
 
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.transferLockedForListing(user1, user2, tokenId, 15, "");
 
         assertEq(roboshareTokens.getLockedAmount(user1, tokenId), 25);
@@ -592,7 +659,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     }
 
     function testBurnCurrentEpochForPrimaryRedemptionNotRevenueToken() public {
-        vm.prank(burner);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
         roboshareTokens.burnCurrentEpochForPrimaryRedemption(user1, 101, 1);
     }
@@ -600,25 +667,37 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     function testBurnCurrentEpochForPrimaryRedemptionZeroAmount() public {
         uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
 
-        vm.prank(burner);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InvalidLockAmount.selector);
         roboshareTokens.burnCurrentEpochForPrimaryRedemption(user1, tokenId, 0);
+    }
+
+    function testManagerBurnCurrentEpochUnauthorizedCaller() public {
+        uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, unauthorized, roboshareTokens.MANAGER_ROLE()
+            )
+        );
+        vm.prank(unauthorized);
+        roboshareTokens.managerBurnCurrentEpoch(user1, tokenId, 1);
     }
 
     function testBurnCurrentEpochForPrimaryRedemptionRequiresEligibleEpochBalance() public {
         uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
         uint256 backedPrincipal = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
 
-        vm.prank(burner);
+        vm.prank(manager);
         roboshareTokens.recordImmediateProceedsRelease(tokenId, backedPrincipal);
 
-        vm.prank(burner);
+        vm.prank(manager);
         vm.expectRevert(TokenLib.InsufficientTokenBalance.selector);
         roboshareTokens.burnCurrentEpochForPrimaryRedemption(user1, tokenId, 1);
     }
 
     function testRecordImmediateProceedsReleaseNotRevenueToken() public {
-        vm.prank(burner);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
         roboshareTokens.recordImmediateProceedsRelease(101, 1);
     }
@@ -628,7 +707,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         uint256 epochBefore = roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId);
         uint256 principalBefore = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
 
-        vm.prank(burner);
+        vm.prank(manager);
         roboshareTokens.recordImmediateProceedsRelease(tokenId, 0);
 
         assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), epochBefore);
@@ -642,7 +721,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         vm.prank(minter);
         roboshareTokens.setRevenueTokenInfo(tokenId, 100 * 1e6, 100, 100, maturityDate, 10_000, 1_000, true, false);
 
-        vm.prank(burner);
+        vm.prank(manager);
         roboshareTokens.recordImmediateProceedsRelease(tokenId, 1);
 
         assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), 0);
@@ -650,7 +729,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
     }
 
     function testRecordPrimaryRedemptionPayoutNotRevenueToken() public {
-        vm.prank(burner);
+        vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
         roboshareTokens.recordPrimaryRedemptionPayout(101, 1);
     }
@@ -660,7 +739,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         uint256 supplyBefore = roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId);
         uint256 principalBefore = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
 
-        vm.prank(burner);
+        vm.prank(manager);
         roboshareTokens.recordPrimaryRedemptionPayout(tokenId, 0);
 
         assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), supplyBefore);
@@ -671,7 +750,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
         uint256 backedPrincipal = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
 
-        vm.prank(burner);
+        vm.prank(manager);
         roboshareTokens.recordPrimaryRedemptionPayout(tokenId, backedPrincipal);
 
         assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), 0);
@@ -686,7 +765,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         vm.prank(burner);
         roboshareTokens.burn(user1, tokenId, 100);
 
-        vm.prank(burner);
+        vm.prank(manager);
         roboshareTokens.recordPrimaryRedemptionPayout(tokenId, principalBefore / 2);
 
         assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), 0);
@@ -717,7 +796,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
 
     function testTransferBlockedWhenLockedAmountExceedsUnlockedBalance() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, 80);
 
         vm.expectRevert(RoboshareTokens.InsufficientUnlockedBalance.selector);
@@ -727,7 +806,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
 
     function testBatchTransferDuplicateRevenueTokenIdsRespectsCumulativeLockedCheck() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, 10); // Available = 90
 
         uint256[] memory ids = new uint256[](2);
@@ -817,10 +896,10 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         lockAmount = bound(lockAmount, 1, mintAmount);
         transferAmount = bound(transferAmount, 1, lockAmount);
 
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.lockForListing(user1, tokenId, lockAmount);
 
-        vm.prank(admin);
+        vm.prank(manager);
         roboshareTokens.transferLockedForListing(user1, user2, tokenId, transferAmount, "");
 
         assertEq(roboshareTokens.getLockedAmount(user1, tokenId), lockAmount - transferAmount);

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -94,7 +94,7 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.setPositionManager(address(testPositionManager));
         minter = admin; // Admin has minter role by default
         burner = admin; // Admin has burner role by default
-        manager = admin; // Admin has manager role by default
+        manager = address(testPositionManager); // PositionManager is the sole manager role holder
 
         // These helpers run against a fork in CI/local workflows, so ensure the
         // deterministic test users are EOAs even if the forked chain has code there.
@@ -158,7 +158,8 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         assertTrue(roboshareTokens.hasRole(roboshareTokens.UPGRADER_ROLE(), admin));
         assertTrue(roboshareTokens.hasRole(roboshareTokens.MINTER_ROLE(), admin));
         assertTrue(roboshareTokens.hasRole(roboshareTokens.MINTER_ROLE(), minter));
-        assertTrue(roboshareTokens.hasRole(roboshareTokens.MANAGER_ROLE(), admin));
+        assertTrue(roboshareTokens.hasRole(roboshareTokens.MANAGER_ROLE(), address(testPositionManager)));
+        assertFalse(roboshareTokens.hasRole(roboshareTokens.MANAGER_ROLE(), admin));
 
         // Verify role hashes
         assertEq(roboshareTokens.MINTER_ROLE(), keccak256("MINTER_ROLE"), "Invalid MINTER_ROLE hash");
@@ -485,11 +486,70 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         vm.prank(admin);
         freshToken.setPositionManager(address(freshManager));
 
+        assertTrue(freshToken.hasRole(freshToken.MANAGER_ROLE(), address(freshManager)));
+        assertFalse(freshToken.hasRole(freshToken.MANAGER_ROLE(), admin));
+
         vm.prank(admin);
         freshToken.mint(user1, tokenId, amount, "");
 
         uint256 penalty = freshToken.getSalesPenalty(user1, tokenId, amount);
         assertGt(penalty, 0, "Penalty should use backfilled manager policy after late manager attach");
+    }
+
+    function testSetPositionManagerSkipsUnsetRevenueTokenSlots() public {
+        RoboshareTokens freshToken = RoboshareTokens(
+            address(
+                new ERC1967Proxy(address(new RoboshareTokens()), abi.encodeWithSignature("initialize(address)", admin))
+            )
+        );
+        PositionManager freshManager = _deployPositionManager(address(freshToken));
+
+        vm.startPrank(admin);
+        freshToken.reserveNextTokenIdPair();
+        (, uint256 configuredTokenId) = freshToken.reserveNextTokenIdPair();
+        vm.stopPrank();
+
+        uint256 amount = 100;
+        uint256 maturityDate = block.timestamp + 365 days;
+
+        vm.prank(admin);
+        freshToken.setRevenueTokenInfo(
+            configuredTokenId, 100 * 1e6, amount, amount, maturityDate, 10_000, 1_000, false, false
+        );
+
+        vm.prank(admin);
+        freshToken.setPositionManager(address(freshManager));
+
+        vm.prank(admin);
+        freshToken.mint(user1, configuredTokenId, amount, "");
+
+        uint256 penalty = freshToken.getSalesPenalty(user1, configuredTokenId, amount);
+        assertGt(penalty, 0, "Configured revenue token should still sync when earlier slots are unset");
+    }
+
+    function testSetPositionManagerZeroAddress() public {
+        vm.expectRevert(RoboshareTokens.ZeroAddress.selector);
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(0));
+    }
+
+    function testManagerRequiredTokenPathsRevertWhenPositionManagerNotSet() public {
+        RoboshareTokens freshToken = RoboshareTokens(
+            address(
+                new ERC1967Proxy(address(new RoboshareTokens()), abi.encodeWithSignature("initialize(address)", admin))
+            )
+        );
+
+        vm.prank(admin);
+        (, uint256 tokenId) = freshToken.reserveNextTokenIdPair();
+        uint256 amount = 100;
+        uint256 maturityDate = block.timestamp + 365 days;
+
+        vm.prank(admin);
+        freshToken.setRevenueTokenInfo(tokenId, 100 * 1e6, amount, amount, maturityDate, 10_000, 1_000, false, false);
+
+        vm.expectRevert(RoboshareTokens.PositionManagerNotSet.selector);
+        freshToken.getLockedAmount(user1, tokenId);
     }
 
     function testGetUserPositionsAndBalance() public {

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -640,6 +640,24 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.lockForListing(user1, tokenId, 0);
     }
 
+    function testLockForListingRejectsLegacyAuthorizedAndBurnerRoles() public {
+        address legacyActor = makeAddr("legacyActor");
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        vm.startPrank(admin);
+        roboshareTokens.grantRole(roboshareTokens.AUTHORIZED_CONTRACT_ROLE(), legacyActor);
+        roboshareTokens.grantRole(roboshareTokens.BURNER_ROLE(), legacyActor);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, legacyActor, roboshareTokens.MANAGER_ROLE()
+            )
+        );
+        vm.prank(legacyActor);
+        roboshareTokens.lockForListing(user1, tokenId, 1);
+    }
+
     function testLockForListingInsufficientUnlockedBalance() public {
         uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
 


### PR DESCRIPTION
Summary
- add MANAGER_ROLE plus manager-scoped token transfer and burn paths in RoboshareTokens
- keep legacy managed token helpers but route them through the manager-scoped redemption path
- tighten raw manager transfer and burn methods to revenue tokens only and cover the new permission model in unit tests

Verification
- yarn workspace evm lint
- forge test --offline --match-path test/unit/RoboshareTokens.t.sol