### PR TITLE
feat(evm): consume manager redemption state in treasury (ROB-77)

### DIFF
--- a/protocols/evm/contracts/Treasury.sol
+++ b/protocols/evm/contracts/Treasury.sol
@@ -12,6 +12,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { IAssetRegistry } from "./interfaces/IAssetRegistry.sol";
 import { ITreasury } from "./interfaces/ITreasury.sol";
 import { IEarningsManager } from "./interfaces/IEarningsManager.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
 import { ProtocolLib, TokenLib, CollateralLib, EarningsLib, AssetLib } from "./Libraries.sol";
 import { RoboshareTokens } from "./RoboshareTokens.sol";
 import { PartnerManager } from "./PartnerManager.sol";
@@ -35,6 +36,7 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
     bytes32 public constant AUTHORIZED_MARKETPLACE_ROLE = keccak256("AUTHORIZED_MARKETPLACE_ROLE");
     bytes32 public constant AUTHORIZED_ROUTER_ROLE = keccak256("AUTHORIZED_ROUTER_ROLE");
     bytes32 public constant AUTHORIZED_EARNINGS_MANAGER_ROLE = keccak256("AUTHORIZED_EARNINGS_MANAGER_ROLE");
+    bytes32 private constant PRIMARY_REDEMPTION_CONSUMED_REASON = keccak256("PRIMARY_REDEMPTION_CONSUMED");
 
     // Core contracts
     PartnerManager public partnerManager;
@@ -92,6 +94,10 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         if (address(earningsManager) == address(0)) {
             revert EarningsManagerNotSet();
         }
+    }
+
+    function _positionManager() internal view returns (IPositionManager) {
+        return roboshareTokens.positionManager();
     }
 
     /**
@@ -218,11 +224,13 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
             revert InsufficientPrimaryLiquidity();
         }
 
-        uint256 redemptionSupply = roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId);
+        IPositionManager manager = _positionManager();
+
+        uint256 redemptionSupply = manager.getCurrentPrimaryRedemptionEpochSupply(tokenId);
         if (redemptionSupply == 0) {
             revert NoRedeemablePrimarySupply();
         }
-        if (roboshareTokens.getPrimaryRedemptionEligibleBalance(holder, tokenId) < burnAmount) {
+        if (manager.getPrimaryRedemptionEligibleBalance(holder, tokenId) < burnAmount) {
             revert InsufficientTokenBalance();
         }
 
@@ -239,7 +247,6 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         }
 
         router.burnRevenueTokensFromHolderForPrimaryRedemption(holder, tokenId, burnAmount);
-        router.recordPrimaryRedemptionPayout(tokenId, payout);
 
         uint256 redeemedPrincipal = burnAmount * roboshareTokens.getTokenPrice(tokenId);
         CollateralLib.CollateralInfo storage collateralInfo = assetCollateral[assetId];
@@ -250,6 +257,7 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         _reconcileReleasedBaseCollateral(collateralInfo);
         totalCollateralDeposited = totalCollateralDeposited >= payout ? totalCollateralDeposited - payout : 0;
         usdc.safeTransfer(holder, payout);
+        manager.consumePrimaryRedemption(holder, tokenId, burnAmount, payout, PRIMARY_REDEMPTION_CONSUMED_REASON);
     }
 
     function _getCoverableBaseCollateral(uint256 assetId) internal view returns (uint256 coverableBaseCollateral) {

--- a/protocols/evm/test/integration/Treasury.Integration.t.sol
+++ b/protocols/evm/test/integration/Treasury.Integration.t.sol
@@ -8,6 +8,7 @@ import { StdStorage, stdStorage } from "forge-std/StdStorage.sol";
 import { MarketplaceFlowBaseTest } from "../base/MarketplaceFlowBaseTest.t.sol";
 import { ProtocolLib, AssetLib, TokenLib, CollateralLib, EarningsLib } from "../../contracts/Libraries.sol";
 import { IAssetRegistry } from "../../contracts/interfaces/IAssetRegistry.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 import { ITreasury } from "../../contracts/interfaces/ITreasury.sol";
 import { PartnerManager } from "../../contracts/PartnerManager.sol";
 
@@ -402,11 +403,15 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     function testProcessPrimaryRedemptionFor() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
 
+        IPositionManager manager = roboshareTokens.positionManager();
         uint256 burnAmount = PRIMARY_PURCHASE_AMOUNT / 2;
         (uint256 preview,,,) = marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, burnAmount);
         assertGt(preview, 0);
 
         CollateralLib.CollateralInfo memory beforeInfo = _getCollateralInfo(scenario.assetId);
+        uint256 supplyBefore = manager.getCurrentPrimaryRedemptionEpochSupply(scenario.revenueTokenId);
+        uint256 principalBefore = manager.getCurrentPrimaryRedemptionBackedPrincipal(scenario.revenueTokenId);
+        uint256 eligibleBefore = manager.getPrimaryRedemptionEligibleBalance(buyer, scenario.revenueTokenId);
         uint256 buyerUsdcBefore = usdc.balanceOf(buyer);
         uint256 buyerTokensBefore = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
 
@@ -417,10 +422,33 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         assertEq(payout, preview);
         assertEq(usdc.balanceOf(buyer), buyerUsdcBefore + payout);
         assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), buyerTokensBefore - burnAmount);
+        assertEq(manager.getCurrentPrimaryRedemptionEpochSupply(scenario.revenueTokenId), supplyBefore - burnAmount);
+        assertEq(manager.getCurrentPrimaryRedemptionBackedPrincipal(scenario.revenueTokenId), principalBefore - payout);
+        assertEq(
+            manager.getPrimaryRedemptionEligibleBalance(buyer, scenario.revenueTokenId), eligibleBefore - burnAmount
+        );
         assertEq(
             afterInfo.unredeemedBasePrincipal,
             beforeInfo.unredeemedBasePrincipal - (burnAmount * roboshareTokens.getTokenPrice(scenario.revenueTokenId))
         );
+    }
+
+    function testProcessPrimaryRedemptionForConsumesManagerStateAfterFullPayout() public {
+        _ensureState(SetupState.PurchasedFromPrimaryPool);
+
+        IPositionManager manager = roboshareTokens.positionManager();
+        uint256 burnAmount = PRIMARY_PURCHASE_AMOUNT;
+        (uint256 preview,,,) = marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, burnAmount);
+        uint256 epochBefore = manager.getCurrentPrimaryRedemptionEpoch(scenario.revenueTokenId);
+
+        vm.prank(address(marketplace));
+        uint256 payout = treasury.processPrimaryRedemptionFor(buyer, scenario.revenueTokenId, burnAmount, preview);
+
+        assertEq(payout, preview);
+        assertEq(manager.getPrimaryRedemptionEligibleBalance(buyer, scenario.revenueTokenId), 0);
+        assertEq(manager.getCurrentPrimaryRedemptionEpochSupply(scenario.revenueTokenId), 0);
+        assertEq(manager.getCurrentPrimaryRedemptionBackedPrincipal(scenario.revenueTokenId), 0);
+        assertEq(manager.getCurrentPrimaryRedemptionEpoch(scenario.revenueTokenId), epochBefore + 1);
     }
 
     function testProcessPrimaryRedemptionForMultipleBurnsPreservesSnapshottedEarnings() public {


### PR DESCRIPTION
Summary
- read primary redemption eligibility and epoch supply from PositionManager in Treasury
- consume manager redemption state after the router burn and payout transfer
- extend Treasury integration coverage for partial and full primary redemption state consumption

Verification
- forge test --offline --match-path test/integration/Treasury.Integration.t.sol