### PR TITLE
feat(evm): move settlement claim accounting to manager (ROB-78)

### DIFF
--- a/protocols/evm/contracts/PositionManager.sol
+++ b/protocols/evm/contracts/PositionManager.sol
@@ -529,18 +529,25 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
         uint256 payout,
         bytes32 reason
     ) external onlyRole(AUTHORIZED_TREASURY_ROLE) {
+        _recordSettlementClaim(assetId, tokenId, account, burnAmount, payout, reason);
+    }
+
+    function creditSettlementClaim(address account, uint256 assetId, uint256 burnAmount, bytes32 reason)
+        external
+        onlyRole(AUTHORIZED_TREASURY_ROLE)
+        returns (uint256 payout)
+    {
+        if (burnAmount == 0) {
+            return 0;
+        }
+
         SettlementStateInternal storage state = _settlementStates[assetId];
         if (!state.isConfigured) {
             revert SettlementNotConfigured(assetId);
         }
 
-        SettlementClaimStateInternal storage claimState = _settlementClaims[assetId][state.epochId][account];
-        claimState.burnedAmount += burnAmount;
-        claimState.payout += payout;
-        state.claimedBurnAmount += burnAmount;
-        state.claimedPayout += payout;
-
-        emit SettlementClaimRecorded(assetId, tokenId, account, burnAmount, payout, reason);
+        payout = burnAmount * state.settlementPerToken;
+        _recordSettlementClaim(assetId, TokenLib.getTokenIdFromAssetId(assetId), account, burnAmount, payout, reason);
     }
 
     function getSettlementState(uint256 assetId) external view returns (SettlementState memory state) {
@@ -614,6 +621,28 @@ contract PositionManager is Initializable, AccessControlUpgradeable, UUPSUpgrade
             tokenInfo.currentRedemptionBackedPrincipal,
             reason
         );
+    }
+
+    function _recordSettlementClaim(
+        uint256 assetId,
+        uint256 tokenId,
+        address account,
+        uint256 burnAmount,
+        uint256 payout,
+        bytes32 reason
+    ) internal {
+        SettlementStateInternal storage state = _settlementStates[assetId];
+        if (!state.isConfigured) {
+            revert SettlementNotConfigured(assetId);
+        }
+
+        SettlementClaimStateInternal storage claimState = _settlementClaims[assetId][state.epochId][account];
+        claimState.burnedAmount += burnAmount;
+        claimState.payout += payout;
+        state.claimedBurnAmount += burnAmount;
+        state.claimedPayout += payout;
+
+        emit SettlementClaimRecorded(assetId, tokenId, account, burnAmount, payout, reason);
     }
 
     function _roboshareTokenManager() internal view returns (IRoboshareTokenManager manager) {

--- a/protocols/evm/contracts/Treasury.sol
+++ b/protocols/evm/contracts/Treasury.sol
@@ -12,6 +12,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { IAssetRegistry } from "./interfaces/IAssetRegistry.sol";
 import { ITreasury } from "./interfaces/ITreasury.sol";
 import { IEarningsManager } from "./interfaces/IEarningsManager.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
 import { ProtocolLib, TokenLib, CollateralLib, EarningsLib, AssetLib } from "./Libraries.sol";
 import { RoboshareTokens } from "./RoboshareTokens.sol";
 import { PartnerManager } from "./PartnerManager.sol";
@@ -92,6 +93,10 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         if (address(earningsManager) == address(0)) {
             revert EarningsManagerNotSet();
         }
+    }
+
+    function _positionManager() internal view returns (IPositionManager) {
+        return roboshareTokens.positionManager();
     }
 
     /**
@@ -862,6 +867,14 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
 
         settlement.isSettled = true;
         settlement.totalSettlementPool = liquidationAmount;
+        _positionManager()
+            .recordSettlement(
+                assetId,
+                _positionManager().getCurrentPrimaryRedemptionEpoch(revenueTokenId),
+                liquidationAmount,
+                settlement.settlementPerToken,
+                keccak256("LIQUIDATION_SETTLEMENT")
+            );
 
         // Update asset status to Expired (liquidation)
         router.setAssetStatus(assetId, AssetLib.AssetStatus.Expired);
@@ -923,7 +936,7 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
             return 0;
         }
 
-        return tokenBalance * settlement.settlementPerToken;
+        return _positionManager().previewSettlementClaim(assetId, tokenBalance);
     }
 
     function initiateSettlement(address partner, uint256 assetId, uint256 topUpAmount)
@@ -959,6 +972,14 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
 
         settlement.isSettled = true;
         settlement.totalSettlementPool = settlementAmount;
+        _positionManager()
+            .recordSettlement(
+                assetId,
+                _positionManager().getCurrentPrimaryRedemptionEpoch(revenueTokenId),
+                settlementAmount,
+                settlement.settlementPerToken,
+                keccak256("VOLUNTARY_SETTLEMENT")
+            );
 
         // Update asset status to Retired
         router.setAssetStatus(assetId, AssetLib.AssetStatus.Retired);
@@ -981,8 +1002,8 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
             return 0;
         }
 
-        // Calculate claim
-        claimedAmount = amount * settlement.settlementPerToken;
+        claimedAmount = _positionManager()
+            .creditSettlementClaim(recipient, assetId, amount, keccak256("TREASURY_SETTLEMENT_CLAIM"));
 
         // Add to pending withdrawals (consistent withdrawal pattern)
         if (claimedAmount > 0) {

--- a/protocols/evm/contracts/interfaces/IPositionManager.sol
+++ b/protocols/evm/contracts/interfaces/IPositionManager.sol
@@ -254,6 +254,10 @@ interface IPositionManager {
         bytes32 reason
     ) external;
 
+    function creditSettlementClaim(address account, uint256 assetId, uint256 burnAmount, bytes32 reason)
+        external
+        returns (uint256 payout);
+
     function getSettlementState(uint256 assetId) external view returns (SettlementState memory state);
 
     function getSettlementClaimState(uint256 assetId, address account)

--- a/protocols/evm/test/integration/Treasury.Integration.t.sol
+++ b/protocols/evm/test/integration/Treasury.Integration.t.sol
@@ -8,11 +8,16 @@ import { StdStorage, stdStorage } from "forge-std/StdStorage.sol";
 import { MarketplaceFlowBaseTest } from "../base/MarketplaceFlowBaseTest.t.sol";
 import { ProtocolLib, AssetLib, TokenLib, CollateralLib, EarningsLib } from "../../contracts/Libraries.sol";
 import { IAssetRegistry } from "../../contracts/interfaces/IAssetRegistry.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 import { ITreasury } from "../../contracts/interfaces/ITreasury.sol";
 import { PartnerManager } from "../../contracts/PartnerManager.sol";
 
 contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     using stdStorage for StdStorage;
+
+    function _positionManager() internal view returns (IPositionManager) {
+        return roboshareTokens.positionManager();
+    }
 
     function setUp() public {
         // Integration tests need funded accounts and authorized partners as a baseline
@@ -957,13 +962,27 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         vm.prank(partner1);
         assetRegistry.settleAsset(scenario.assetId, 0);
 
+        IPositionManager positionManager = _positionManager();
+        IPositionManager.SettlementState memory settlementState = positionManager.getSettlementState(scenario.assetId);
+        assertTrue(settlementState.isConfigured, "PositionManager settlement should be configured");
+
+        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
         uint256 previewAmount = treasury.previewSettlementClaim(scenario.assetId, buyer);
         assertGt(previewAmount, 0, "Settled preview should be positive");
+        assertEq(
+            previewAmount,
+            positionManager.previewSettlementClaim(scenario.assetId, buyerBalance),
+            "Treasury preview should use PositionManager settlement rate"
+        );
 
         vm.prank(buyer);
         (uint256 settlementClaimed,) = assetRegistry.claimSettlement(scenario.assetId, false);
 
         assertEq(settlementClaimed, previewAmount, "Preview should match settlement claimed");
+        IPositionManager.SettlementClaimState memory claimState =
+            positionManager.getSettlementClaimState(scenario.assetId, buyer);
+        assertEq(claimState.burnedAmount, buyerBalance, "PositionManager should track claimed burn amount");
+        assertEq(claimState.payout, settlementClaimed, "PositionManager should track claimed payout");
         assertEq(treasury.previewSettlementClaim(scenario.assetId, buyer), 0, "Preview should be zero after claim");
     }
 

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -668,6 +668,53 @@ contract PositionManagerTest is Test {
         assertEq(claimState.payout, 225);
     }
 
+    function testCreditSettlementClaimUsesConfiguredSettlementRate() public {
+        vm.prank(treasury);
+        positionManager.recordSettlement(ASSET_ID, 4, 900, 9, SETTLE_REASON);
+
+        vm.expectEmit(true, true, true, true, address(positionManager));
+        emit SettlementClaimRecorded(ASSET_ID, TOKEN_ID, alice, 20, 180, CLAIM_REASON);
+
+        vm.prank(treasury);
+        uint256 payout = positionManager.creditSettlementClaim(alice, ASSET_ID, 20, CLAIM_REASON);
+
+        assertEq(payout, 180);
+
+        IPositionManager.SettlementState memory settlement = positionManager.getSettlementState(ASSET_ID);
+        assertEq(settlement.claimedBurnAmount, 20);
+        assertEq(settlement.claimedPayout, 180);
+
+        IPositionManager.SettlementClaimState memory claimState =
+            positionManager.getSettlementClaimState(ASSET_ID, alice);
+        assertEq(claimState.burnedAmount, 20);
+        assertEq(claimState.payout, 180);
+    }
+
+    function testCreditSettlementClaimReturnsZeroForZeroBurnAmount() public {
+        vm.prank(treasury);
+        positionManager.recordSettlement(ASSET_ID, 4, 900, 9, SETTLE_REASON);
+
+        vm.prank(treasury);
+        uint256 payout = positionManager.creditSettlementClaim(alice, ASSET_ID, 0, CLAIM_REASON);
+
+        assertEq(payout, 0);
+
+        IPositionManager.SettlementState memory settlement = positionManager.getSettlementState(ASSET_ID);
+        assertEq(settlement.claimedBurnAmount, 0);
+        assertEq(settlement.claimedPayout, 0);
+
+        IPositionManager.SettlementClaimState memory claimState =
+            positionManager.getSettlementClaimState(ASSET_ID, alice);
+        assertEq(claimState.burnedAmount, 0);
+        assertEq(claimState.payout, 0);
+    }
+
+    function testCreditSettlementClaimRevertsWhenSettlementNotConfigured() public {
+        vm.expectRevert(abi.encodeWithSelector(IPositionManager.SettlementNotConfigured.selector, ASSET_ID));
+        vm.prank(treasury);
+        positionManager.creditSettlementClaim(alice, ASSET_ID, 1, CLAIM_REASON);
+    }
+
     function testSettlementClaimsResetAcrossEpochs() public {
         vm.startPrank(treasury);
         positionManager.recordSettlement(ASSET_ID, 4, 900, 9, SETTLE_REASON);


### PR DESCRIPTION
Summary
- add a manager-owned settlement credit primitive and reuse shared claim bookkeeping in PositionManager
- record settlement configuration from Treasury into PositionManager for voluntary settlement and liquidation
- switch Treasury settlement preview and claim accounting to manager-backed state and add focused integration assertions

Verification
- forge test --offline --match-path test/unit/PositionManager.t.sol
- forge test --offline --match-path test/integration/Treasury.Integration.t.sol