### PR TITLE
feat(evm): align terminal settlement flows with manager model (ROB-79)

### DIFF
--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -241,10 +241,12 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
             revert TreasuryNotSet();
         }
 
+        uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(assetId);
         (settlementAmount, settlementPerToken) = ITreasury(treasury).initiateSettlement(partner, assetId, topUpAmount);
+        IAssetRegistry(idToRegistry[assetId]).setAssetStatus(assetId, AssetLib.AssetStatus.Retired);
 
         // Best-effort: settlement should close primary pool if it exists.
-        _closePrimaryPoolIfMarketplaceConfigured(TokenLib.getTokenIdFromAssetId(assetId));
+        _closePrimaryPoolIfMarketplaceConfigured(revenueTokenId);
     }
 
     /**
@@ -265,10 +267,12 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
             revert TreasuryNotSet();
         }
 
+        uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(assetId);
         (liquidationAmount, settlementPerToken) = ITreasury(treasury).executeLiquidation(assetId);
+        IAssetRegistry(idToRegistry[assetId]).setAssetStatus(assetId, AssetLib.AssetStatus.Expired);
 
         // Best-effort: liquidation should close primary pool if it exists.
-        _closePrimaryPoolIfMarketplaceConfigured(TokenLib.getTokenIdFromAssetId(assetId));
+        _closePrimaryPoolIfMarketplaceConfigured(revenueTokenId);
     }
 
     /**
@@ -281,7 +285,8 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         returns (uint256 claimedAmount)
     {
         // Verify this registry owns the asset
-        if (idToRegistry[assetId] != msg.sender) {
+        address registry = idToRegistry[assetId];
+        if (registry != msg.sender) {
             revert RegistryNotBoundToAsset();
         }
 

--- a/protocols/evm/contracts/Treasury.sol
+++ b/protocols/evm/contracts/Treasury.sol
@@ -100,6 +100,14 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         return roboshareTokens.positionManager();
     }
 
+    function _isSettlementConfigured(uint256 assetId) internal view returns (bool) {
+        return _positionManager().getSettlementState(assetId).isConfigured;
+    }
+
+    function _isTerminalAssetStatus(AssetLib.AssetStatus status) internal pure returns (bool) {
+        return status == AssetLib.AssetStatus.Retired || status == AssetLib.AssetStatus.Expired;
+    }
+
     /**
      * @notice Initializes the treasury and wires its core protocol dependencies.
      * @param _admin Address receiving admin, upgrader, and treasurer roles
@@ -477,8 +485,12 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
     }
 
     function isAssetSolvent(uint256 assetId) external view override returns (bool) {
-        // An asset is solvent if it hasn't been settled AND is not currently under financial distress
-        return !assetSettlements[assetId].isSettled && CollateralLib.isSolvent(assetCollateral[assetId]);
+        AssetLib.AssetStatus status = router.getAssetStatus(assetId);
+        if (_isTerminalAssetStatus(status) || _isSettlementConfigured(assetId)) {
+            return false;
+        }
+
+        return CollateralLib.isSolvent(assetCollateral[assetId]);
     }
 
     function previewCollateralRelease(uint256 assetId, uint256 pendingNetEarnings)
@@ -794,8 +806,8 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         override
         returns (bool eligible, uint8 reason)
     {
-        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
-        if (settlement.isSettled) {
+        AssetLib.AssetStatus status = router.getAssetStatus(assetId);
+        if (_isTerminalAssetStatus(status) || _isSettlementConfigured(assetId)) {
             return (false, 2);
         }
 
@@ -843,10 +855,12 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         onlyRole(AUTHORIZED_ROUTER_ROLE)
         returns (uint256 liquidationAmount, uint256 settlementPerToken)
     {
-        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
-        if (settlement.isSettled) {
-            revert IAssetRegistry.AssetAlreadySettled(assetId, router.getAssetStatus(assetId));
+        AssetLib.AssetStatus currentStatus = router.getAssetStatus(assetId);
+        if (_isTerminalAssetStatus(currentStatus) || _isSettlementConfigured(assetId)) {
+            revert IAssetRegistry.AssetAlreadySettled(assetId, currentStatus);
         }
+
+        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
 
         _applyMissedEarningsShortfall(assetId);
 
@@ -878,11 +892,8 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
                 settlement.settlementPerToken,
                 keccak256("LIQUIDATION_SETTLEMENT")
             );
-
-        // Update asset status to Expired (liquidation)
-        router.setAssetStatus(assetId, AssetLib.AssetStatus.Expired);
-
-        return (liquidationAmount, settlement.settlementPerToken);
+        settlementPerToken = settlement.settlementPerToken;
+        return (liquidationAmount, settlementPerToken);
     }
 
     function _applyMissedEarningsShortfall(uint256 assetId) internal {
@@ -932,10 +943,9 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
     function previewSettlementClaim(uint256 assetId, address holder) external view returns (uint256) {
         _requireAssetExists(assetId);
 
-        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(assetId);
         uint256 tokenBalance = roboshareTokens.balanceOf(holder, revenueTokenId);
-        if (!settlement.isSettled || tokenBalance == 0) {
+        if (!_isSettlementConfigured(assetId) || tokenBalance == 0) {
             return 0;
         }
 
@@ -948,10 +958,12 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         onlyRole(AUTHORIZED_ROUTER_ROLE)
         returns (uint256 settlementAmount, uint256 settlementPerToken)
     {
-        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
-        if (settlement.isSettled) {
-            revert IAssetRegistry.AssetAlreadySettled(assetId, router.getAssetStatus(assetId));
+        AssetLib.AssetStatus currentStatus = router.getAssetStatus(assetId);
+        if (_isTerminalAssetStatus(currentStatus) || _isSettlementConfigured(assetId)) {
+            revert IAssetRegistry.AssetAlreadySettled(assetId, currentStatus);
         }
+
+        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
 
         // Transfer top-up if any
         if (topUpAmount > 0) {
@@ -983,11 +995,8 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
                 settlement.settlementPerToken,
                 keccak256("VOLUNTARY_SETTLEMENT")
             );
-
-        // Update asset status to Retired
-        router.setAssetStatus(assetId, AssetLib.AssetStatus.Retired);
-
-        return (settlementAmount, settlement.settlementPerToken);
+        settlementPerToken = settlement.settlementPerToken;
+        return (settlementAmount, settlementPerToken);
     }
 
     function processSettlementClaimFor(address recipient, uint256 assetId, uint256 amount)
@@ -996,8 +1005,7 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
         onlyRole(AUTHORIZED_ROUTER_ROLE)
         returns (uint256 claimedAmount)
     {
-        CollateralLib.SettlementInfo storage settlement = assetSettlements[assetId];
-        if (!settlement.isSettled) {
+        if (!_isSettlementConfigured(assetId)) {
             revert IAssetRegistry.AssetNotSettled(assetId, router.getAssetStatus(assetId));
         }
 
@@ -1007,11 +1015,7 @@ contract Treasury is Initializable, AccessControlUpgradeable, UUPSUpgradeable, R
 
         claimedAmount = _positionManager()
             .creditSettlementClaim(recipient, assetId, amount, keccak256("TREASURY_SETTLEMENT_CLAIM"));
-
-        // Add to pending withdrawals (consistent withdrawal pattern)
-        if (claimedAmount > 0) {
-            pendingWithdrawals[recipient] += claimedAmount;
-        }
+        pendingWithdrawals[recipient] += claimedAmount;
 
         emit SettlementClaimed(assetId, recipient, claimedAmount);
     }

--- a/protocols/evm/contracts/interfaces/ITreasury.sol
+++ b/protocols/evm/contracts/interfaces/ITreasury.sol
@@ -213,10 +213,10 @@ interface ITreasury {
     function previewLiquidationEligibility(uint256 assetId) external view returns (bool eligible, uint8 reason);
 
     /**
-     * @notice Forces liquidation for an eligible asset and records a settlement pool for holders.
+     * @notice Forces liquidation for an eligible asset and computes the settlement pool for holders.
      * @param assetId Asset to liquidate
      * @return liquidationAmount Total USDC placed into the liquidation settlement pool
-     * @return settlementPerToken Integer per-token settlement rate recorded for later claims
+     * @return settlementPerToken Integer per-token settlement rate recorded in the manager for later claims
      */
     function executeLiquidation(uint256 assetId)
         external
@@ -236,7 +236,7 @@ interface ITreasury {
      * @param assetId Asset being voluntarily settled
      * @param topUpAmount Additional USDC contributed by the partner before settlement
      * @return settlementAmount Total USDC made available to token holders through settlement
-     * @return settlementPerToken Integer per-token settlement rate recorded for later claims
+     * @return settlementPerToken Integer per-token settlement rate recorded in the manager for later claims
      */
     function initiateSettlement(address partner, uint256 assetId, uint256 topUpAmount)
         external

--- a/protocols/evm/test/integration/Treasury.Integration.t.sol
+++ b/protocols/evm/test/integration/Treasury.Integration.t.sol
@@ -1690,9 +1690,8 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     function testInitiateSettlementAlreadySettled() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
 
-        // First settlement via Treasury directly (simulating router call)
-        vm.prank(address(router));
-        treasury.initiateSettlement(partner1, scenario.assetId, 0);
+        vm.prank(partner1);
+        assetRegistry.settleAsset(scenario.assetId, 0);
 
         // Second settlement should revert with IAssetRegistry.AssetAlreadySettled
         vm.prank(address(router));
@@ -1708,9 +1707,8 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     function testExecuteLiquidationAlreadySettled() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
 
-        // First: settle via Treasury directly (simulating router call)
-        vm.prank(address(router));
-        treasury.initiateSettlement(partner1, scenario.assetId, 0);
+        vm.prank(partner1);
+        assetRegistry.settleAsset(scenario.assetId, 0);
 
         (bool eligible, uint8 reason) = treasury.previewLiquidationEligibility(scenario.assetId);
         assertFalse(eligible);

--- a/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
+++ b/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
@@ -15,6 +15,7 @@ import { EarningsManager } from "../../contracts/EarningsManager.sol";
 import { Marketplace } from "../../contracts/Marketplace.sol";
 import { AssetLib, VehicleLib, CollateralLib, ProtocolLib, EarningsLib } from "../../contracts/Libraries.sol";
 import { IAssetRegistry } from "../../contracts/interfaces/IAssetRegistry.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 import { ITreasury } from "../../contracts/interfaces/ITreasury.sol";
 import { PartnerManager } from "../../contracts/PartnerManager.sol";
 import { VehicleRegistry } from "../../contracts/VehicleRegistry.sol";
@@ -87,6 +88,10 @@ contract VehicleRegistryIntegrationHelper is Test {
 
 contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceFlowBaseTest {
     VehicleRegistryIntegrationHelper internal helper;
+
+    function _positionManager() internal view returns (IPositionManager) {
+        return roboshareTokens.positionManager();
+    }
 
     function setUp() public {
         _ensureState(SetupState.InitialAccountsSetup);
@@ -765,6 +770,9 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         vm.prank(partner1);
         assetRegistry.settleAsset(scenario.assetId, topUpAmount);
 
+        IPositionManager.SettlementState memory settlementState =
+            _positionManager().getSettlementState(scenario.assetId);
+        assertTrue(settlementState.isConfigured);
         assertEq(uint8(assetRegistry.getAssetStatus(scenario.assetId)), uint8(AssetLib.AssetStatus.Retired));
         assertFalse(marketplace.isPrimaryPoolActive(scenario.revenueTokenId));
     }
@@ -787,9 +795,14 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
 
         (bool isSettled, uint256 settlementPerToken, uint256 totalSettlementPool) =
             treasury.assetSettlements(scenario.assetId);
+        IPositionManager.SettlementState memory settlementState =
+            _positionManager().getSettlementState(scenario.assetId);
         assertTrue(isSettled);
+        assertTrue(settlementState.isConfigured);
         assertEq(totalSettlementPool, expectedLiquidationAmount);
         assertEq(settlementPerToken, expectedPerToken);
+        assertEq(settlementState.settlementAmount, expectedLiquidationAmount);
+        assertEq(settlementState.settlementPerToken, expectedPerToken);
         assertEq(uint8(assetRegistry.getAssetStatus(scenario.assetId)), uint8(AssetLib.AssetStatus.Expired));
         assertFalse(marketplace.isPrimaryPoolActive(scenario.revenueTokenId));
     }
@@ -827,9 +840,13 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         uint256 expectedPerToken = totalSupply > 0 ? expectedLiquidationAmount / totalSupply : 0;
 
         (bool isSettled, uint256 settlementPerToken, uint256 totalSettlementPool) = treasury.assetSettlements(assetId);
+        IPositionManager.SettlementState memory settlementState = _positionManager().getSettlementState(assetId);
         assertTrue(isSettled);
+        assertTrue(settlementState.isConfigured);
         assertEq(totalSettlementPool, expectedLiquidationAmount);
         assertEq(settlementPerToken, expectedPerToken);
+        assertEq(settlementState.settlementAmount, expectedLiquidationAmount);
+        assertEq(settlementState.settlementPerToken, expectedPerToken);
         assertEq(uint8(assetRegistry.getAssetStatus(assetId)), uint8(AssetLib.AssetStatus.Expired));
     }
 

--- a/protocols/evm/test/unit/Treasury.t.sol
+++ b/protocols/evm/test/unit/Treasury.t.sol
@@ -448,6 +448,7 @@ contract TreasuryTest is TreasuryFlowBaseTest {
     }
 
     function testPreviewLiquidationEligibilityEarningsManagerNotSet() public {
+        _ensureState(SetupState.AssetRegistered);
         vm.store(address(treasury), bytes32(uint256(3)), bytes32(0));
 
         vm.expectRevert(ITreasury.EarningsManagerNotSet.selector);


### PR DESCRIPTION
Summary
- move terminal asset status transitions and primary-pool shutdown orchestration onto RegistryRouter after settlement or liquidation completes
- treat manager settlement state as the canonical terminal gate in Treasury while keeping Treasury as the authorized settlement writer
- extend Treasury and VehicleRegistry integration coverage for the terminal settlement and liquidation boundary shifts

Verification
- yarn workspace evm lint
- forge test --offline --match-path test/integration/Treasury.Integration.t.sol
- forge test --offline --match-path test/integration/VehicleRegistry.Integration.t.sol
- forge test --offline --match-path test/integration/RegistryRouter.Integration.t.sol