### PR TITLE
feat(evm): make pool sizing explicit at issuance (ROB-97)

### DIFF
--- a/docs/evm-token-metadata-boundary.md
+++ b/docs/evm-token-metadata-boundary.md
@@ -10,9 +10,9 @@ This document defines the metadata model between `VehicleRegistry` and `Roboshar
   - asset NFT metadata URI pointer (`ipfs://...`)
   - paired revenue-token metadata URI pointer (`ipfs://...`)
 - **Transitional legacy state:**
-  - `assetValue` still exists because current pool creation derives issuance from it.
+  - `assetValue` still exists in registry asset info for legacy accounting/display compatibility.
+  - Pool sizing no longer derives issuance from `assetValue`; explicit pool-size terms such as `maxSupply` are authoritative.
   - The target boundary does not treat appraisal/display value as registry business metadata or as the source of pool sizing.
-  - ROB-97 owns removing `assetValue`-driven issuance in favor of explicit pool-size terms such as `maxSupply`.
 - **Protocol/economic terms (trusted on-chain when contracts use them):**
   - token price or current price/NAV, depending on the final pricing model
   - maturity date

--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -163,7 +163,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
             );
     }
 
-    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 tokenPrice)
+    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 requestedSupply)
         external
         view
         override
@@ -173,7 +173,7 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         if (registry == address(0)) {
             revert RegistryNotFound(assetId);
         }
-        return IAssetRegistry(registry).previewCreateRevenueTokenPool(assetId, partner, tokenPrice);
+        return IAssetRegistry(registry).previewCreateRevenueTokenPool(assetId, partner, requestedSupply);
     }
 
     function registerAssetAndCreateRevenueTokenPool(
@@ -576,14 +576,13 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
             revert RegistryNotFound(assetId);
         }
 
-        (tokenId, supply) = IAssetRegistry(registry).previewCreateRevenueTokenPool(assetId, partner, tokenPrice);
-        uint256 poolMaxSupply = maxSupply == 0 ? supply : maxSupply;
+        (tokenId, supply) = IAssetRegistry(registry).previewCreateRevenueTokenPool(assetId, partner, maxSupply);
 
         roboshareTokens.setRevenueTokenInfo(
             tokenId,
             tokenPrice,
             supply,
-            poolMaxSupply,
+            supply,
             maturityDate,
             revenueShareBP,
             targetYieldBP,

--- a/protocols/evm/contracts/VehicleRegistry.sol
+++ b/protocols/evm/contracts/VehicleRegistry.sol
@@ -186,7 +186,7 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
         );
     }
 
-    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 tokenPrice)
+    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 requestedSupply)
         external
         view
         override
@@ -207,9 +207,11 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
         if (roboshareTokens.getRevenueTokenSupply(revenueTokenId) > 0) {
             revert RevenueTokensAlreadyMinted();
         }
+        if (requestedSupply == 0) {
+            revert InvalidPoolSupply();
+        }
 
-        uint256 assetValue = vehicles[assetId].assetInfo.assetValue;
-        supply = assetValue / tokenPrice;
+        supply = requestedSupply;
     }
 
     /**

--- a/protocols/evm/contracts/interfaces/IAssetRegistry.sol
+++ b/protocols/evm/contracts/interfaces/IAssetRegistry.sol
@@ -41,6 +41,7 @@ interface IAssetRegistry {
     error AssetNotEligibleForLiquidation(uint256 assetId);
     error AssetNotSettled(uint256 assetId, AssetLib.AssetStatus currentStatus);
     error InsufficientTokenBalance(uint256 tokenId, uint256 required, uint256 available);
+    error InvalidPoolSupply();
 
     /**
      * @dev Asset registration and revenue token pool creation.
@@ -77,11 +78,11 @@ interface IAssetRegistry {
      * Reverts if the asset is invalid or caller is not authorized.
      * @param assetId The asset ID
      * @param partner The partner initiating the pool creation
-     * @param tokenPrice Price per revenue token in USDC
+     * @param requestedSupply Explicit pool size to validate
      * @return tokenId The revenue token ID
-     * @return supply The computed token supply
+     * @return supply The approved token supply
      */
-    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 tokenPrice)
+    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 requestedSupply)
         external
         view
         returns (uint256 tokenId, uint256 supply);

--- a/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
+++ b/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
@@ -46,13 +46,14 @@ contract MockRegistry is IAssetRegistry {
 
         // 3. Compute supply for preview + mint flow
         uint256 maturityDate = block.timestamp + 365 days;
+        uint256 supplyToOffer = assetValue / tokenPrice;
 
         // Mint Asset NFT first so partner owns it for collateral locking
         roboshareTokens.mint(partner, assetId, 1, "");
 
         // 4. Configure token economics and create the primary pool through the router flow.
         (revenueTokenId, supply) = router.createRevenueTokenPoolFor(
-            partner, assetId, tokenPrice, maturityDate, 10_000, 1_000, 0, false, false
+            partner, assetId, tokenPrice, maturityDate, 10_000, 1_000, supplyToOffer, false, false
         );
 
         return (assetId, revenueTokenId, supply);
@@ -107,7 +108,7 @@ contract MockRegistry is IAssetRegistry {
         return (0, 0);
     }
 
-    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 tokenPrice)
+    function previewCreateRevenueTokenPool(uint256 assetId, address partner, uint256 requestedSupply)
         external
         view
         override
@@ -124,8 +125,11 @@ contract MockRegistry is IAssetRegistry {
         if (roboshareTokens.getRevenueTokenSupply(tokenId) > 0) {
             revert RevenueTokensAlreadyMinted();
         }
+        if (requestedSupply == 0) {
+            revert InvalidPoolSupply();
+        }
 
-        supply = assets[assetId].info.assetValue / tokenPrice;
+        supply = requestedSupply;
     }
 
     function setAssetStatus(uint256, AssetLib.AssetStatus) external override { }
@@ -246,13 +250,15 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
         // Register asset only
         vm.startPrank(partner1);
         uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
+        uint256 explicitSupply = (ASSET_VALUE / REVENUE_TOKEN_PRICE) / 2;
 
         (uint256 revenueTokenId, uint256 tokenSupply) = router.createRevenueTokenPool(
-            assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
+            assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, explicitSupply, false, false
         );
         vm.stopPrank();
 
         assertEq(uint8(assetRegistry.getAssetStatus(assetId)), uint8(AssetLib.AssetStatus.Active));
+        assertEq(tokenSupply, explicitSupply);
         assertEq(roboshareTokens.balanceOf(address(marketplace), revenueTokenId), 0);
         assertEq(roboshareTokens.getRevenueTokenSupply(revenueTokenId), 0);
         Marketplace.PrimaryPool memory pool = marketplace.getPrimaryPool(revenueTokenId);
@@ -345,23 +351,37 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
         vm.prank(buyer);
         router.createRevenueTokenPool(
-            scenario.assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
+            scenario.assetId,
+            REVENUE_TOKEN_PRICE,
+            block.timestamp + 365 days,
+            10_000,
+            1_000,
+            ASSET_VALUE / REVENUE_TOKEN_PRICE,
+            false,
+            false
         );
     }
 
     function testPreviewMintRevenueTokensRegistryNotFound() public {
         uint256 nonExistentAssetId = 999;
         vm.expectRevert(abi.encodeWithSelector(RegistryRouter.RegistryNotFound.selector, nonExistentAssetId));
-        router.previewCreateRevenueTokenPool(nonExistentAssetId, partner1, REVENUE_TOKEN_PRICE);
+        router.previewCreateRevenueTokenPool(nonExistentAssetId, partner1, ASSET_VALUE / REVENUE_TOKEN_PRICE);
     }
 
     function testPreviewMintRevenueTokens() public {
         _ensureState(SetupState.AssetRegistered);
+        uint256 explicitSupply = (ASSET_VALUE / REVENUE_TOKEN_PRICE) / 2;
         (uint256 tokenId, uint256 supply) =
-            router.previewCreateRevenueTokenPool(scenario.assetId, partner1, REVENUE_TOKEN_PRICE);
+            router.previewCreateRevenueTokenPool(scenario.assetId, partner1, explicitSupply);
 
         assertEq(tokenId, TokenLib.getTokenIdFromAssetId(scenario.assetId));
-        assertEq(supply, ASSET_VALUE / REVENUE_TOKEN_PRICE);
+        assertEq(supply, explicitSupply);
+    }
+
+    function testPreviewMintRevenueTokensZeroSupply() public {
+        _ensureState(SetupState.AssetRegistered);
+        vm.expectRevert(IAssetRegistry.InvalidPoolSupply.selector);
+        router.previewCreateRevenueTokenPool(scenario.assetId, partner1, 0);
     }
 
     function testGetAssetStatusRegistryNotFound() public {
@@ -588,11 +608,20 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
 
         vm.prank(partner1);
         uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
+        uint256 explicitSupply = ASSET_VALUE / REVENUE_TOKEN_PRICE;
 
         vm.prank(address(assetRegistry));
         vm.expectRevert();
         proxyRouter.createRevenueTokenPoolFor(
-            partner1, assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
+            partner1,
+            assetId,
+            REVENUE_TOKEN_PRICE,
+            block.timestamp + 365 days,
+            10_000,
+            1_000,
+            explicitSupply,
+            false,
+            false
         );
     }
 

--- a/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
+++ b/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
@@ -189,6 +189,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         _ensureState(SetupState.InitialAccountsSetup);
 
         bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
+        uint256 explicitSupply = (ASSET_VALUE / REVENUE_TOKEN_PRICE) / 2;
 
         vm.prank(partner1);
         (uint256 assetId, uint256 revenueTokenId, uint256 supply) = assetRegistry.registerAssetAndCreateRevenueTokenPool(
@@ -198,14 +199,14 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
             block.timestamp + 365 days,
             10_000,
             1_000,
-            ASSET_VALUE / REVENUE_TOKEN_PRICE,
+            explicitSupply,
             false,
             false
         );
 
         assertEq(assetId, 1);
         assertEq(revenueTokenId, 2);
-        assertEq(supply, ASSET_VALUE / REVENUE_TOKEN_PRICE);
+        assertEq(supply, explicitSupply);
         assertTrue(marketplace.isPrimaryPoolActive(revenueTokenId));
         assertEq(uint8(assetRegistry.getAssetStatus(assetId)), uint8(AssetLib.AssetStatus.Active));
     }
@@ -220,14 +221,15 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
 
         vm.startPrank(partner1);
         uint256 assetId = assetRegistry.registerAsset(_vehicleRegistrationData(TEST_VIN), ASSET_VALUE);
+        uint256 explicitSupply = (ASSET_VALUE / REVENUE_TOKEN_PRICE) / 2;
 
         (uint256 revenueTokenId, uint256 tokenSupply) = assetRegistry.createRevenueTokenPool(
-            assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
+            assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, explicitSupply, false, false
         );
         vm.stopPrank();
 
         assertEq(uint8(assetRegistry.getAssetStatus(assetId)), uint8(AssetLib.AssetStatus.Active));
-        assertEq(tokenSupply, ASSET_VALUE / REVENUE_TOKEN_PRICE);
+        assertEq(tokenSupply, explicitSupply);
         assertEq(roboshareTokens.balanceOf(address(marketplace), revenueTokenId), 0);
         assertEq(roboshareTokens.getRevenueTokenSupply(revenueTokenId), 0);
     }
@@ -261,7 +263,14 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
         vm.prank(unauthorized);
         assetRegistry.createRevenueTokenPool(
-            assetId, REVENUE_TOKEN_PRICE, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
+            assetId,
+            REVENUE_TOKEN_PRICE,
+            block.timestamp + 365 days,
+            10_000,
+            1_000,
+            ASSET_VALUE / REVENUE_TOKEN_PRICE,
+            false,
+            false
         );
     }
 
@@ -344,19 +353,19 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     function testPreviewMintRevenueTokensAssetNotFound() public {
         _ensureState(SetupState.InitialAccountsSetup);
         vm.expectRevert(abi.encodeWithSelector(IAssetRegistry.AssetNotFound.selector, 999));
-        assetRegistry.previewCreateRevenueTokenPool(999, partner1, REVENUE_TOKEN_PRICE);
+        assetRegistry.previewCreateRevenueTokenPool(999, partner1, ASSET_VALUE / REVENUE_TOKEN_PRICE);
     }
 
     function testPreviewMintRevenueTokensUnauthorizedPartner() public {
         _ensureState(SetupState.AssetRegistered);
         vm.expectRevert(PartnerManager.UnauthorizedPartner.selector);
-        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, unauthorized, REVENUE_TOKEN_PRICE);
+        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, unauthorized, ASSET_VALUE / REVENUE_TOKEN_PRICE);
     }
 
     function testPreviewMintRevenueTokensNotAssetOwner() public {
         _ensureState(SetupState.AssetRegistered);
         vm.expectRevert(IAssetRegistry.NotAssetOwner.selector);
-        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, partner2, REVENUE_TOKEN_PRICE);
+        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, partner2, ASSET_VALUE / REVENUE_TOKEN_PRICE);
     }
 
     function testPreviewMintRevenueTokensAlreadyMinted() public {
@@ -369,7 +378,13 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         vm.stopPrank();
 
         vm.expectRevert(IAssetRegistry.RevenueTokensAlreadyMinted.selector);
-        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, partner1, REVENUE_TOKEN_PRICE);
+        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, partner1, ASSET_VALUE / REVENUE_TOKEN_PRICE);
+    }
+
+    function testPreviewMintRevenueTokensZeroSupply() public {
+        _ensureState(SetupState.AssetRegistered);
+        vm.expectRevert(IAssetRegistry.InvalidPoolSupply.selector);
+        assetRegistry.previewCreateRevenueTokenPool(scenario.assetId, partner1, 0);
     }
 
     // View Function Tests
@@ -402,13 +417,15 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
 
     // Fuzz Tests
 
-    function testFuzzRegisterAssetAndMintTokens(uint256 assetValue, uint256 tokenPrice) public {
+    function testFuzzRegisterAssetAndMintTokens(uint256 assetValue, uint256 tokenPrice, uint256 explicitSupply) public {
         // Constraints:
-        // 1. tokenPrice > 0 (avoid div by zero)
-        // 2. assetValue >= tokenPrice (to ensure supply >= 1)
-        // 3. Cap assetValue at 1B USDC to avoid overflow/unrealistic scenarios
+        // 1. tokenPrice > 0 and realistically bounded
+        // 2. explicitSupply > 0 to satisfy explicit pool sizing
+        // 3. Cap assetValue at 1B USDC to avoid unrealistic scenarios
         vm.assume(tokenPrice > 0);
-        vm.assume(assetValue >= tokenPrice && assetValue <= 1_000_000_000 * 1e6);
+        vm.assume(tokenPrice <= 1_000_000_000 * 1e6);
+        vm.assume(assetValue <= 1_000_000_000 * 1e6);
+        vm.assume(explicitSupply > 0 && explicitSupply <= 1_000_000_000);
 
         _ensureState(SetupState.InitialAccountsSetup);
 
@@ -427,12 +444,12 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
 
         (uint256 assetId, uint256 revenueTokenId, uint256 actualSupply) = assetRegistry.registerAssetAndCreateRevenueTokenPool(
-            vehicleData, assetValue, tokenPrice, maturityDate, 10_000, 1_000, 0, false, false
+            vehicleData, assetValue, tokenPrice, maturityDate, 10_000, 1_000, explicitSupply, false, false
         );
         vm.stopPrank();
 
         assertEq(roboshareTokens.balanceOf(address(marketplace), revenueTokenId), 0);
-        assertEq(actualSupply, assetValue / tokenPrice, "Supply should be derived from asset value and price");
+        assertEq(actualSupply, explicitSupply, "Supply should match explicit pool size");
 
         // Buffers are not funded by pool creation alone.
         CollateralLib.CollateralInfo memory info = _getCollateralInfo(assetId);
@@ -440,13 +457,19 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         assertEq(info.isLocked, false);
     }
 
-    function testFuzzRegisterAssetAndCreateRevenueTokenPool(uint256 assetValue, uint256 tokenPrice) public {
+    function testFuzzRegisterAssetAndCreateRevenueTokenPool(
+        uint256 assetValue,
+        uint256 tokenPrice,
+        uint256 explicitSupply
+    ) public {
         // Constraints:
-        // 1. tokenPrice >= 1 USDC (1e6)
-        // 2. assetValue >= tokenPrice (to ensure supply >= 1)
-        // 3. Cap assetValue at 1B USDC to avoid overflow/unrealistic scenarios
+        // 1. tokenPrice >= 1 USDC (1e6) and realistically bounded
+        // 2. explicitSupply > 0 to satisfy explicit pool sizing
+        // 3. Cap assetValue at 1B USDC to avoid unrealistic scenarios
         vm.assume(tokenPrice >= 1e6);
-        vm.assume(assetValue >= tokenPrice && assetValue <= 1_000_000_000 * 1e6);
+        vm.assume(tokenPrice <= 1_000_000_000 * 1e6);
+        vm.assume(assetValue <= 1_000_000_000 * 1e6);
+        vm.assume(explicitSupply > 0 && explicitSupply <= 1_000_000_000);
 
         _ensureState(SetupState.InitialAccountsSetup);
 
@@ -461,13 +484,11 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         bytes memory vehicleData = _vehicleRegistrationData(TEST_VIN);
 
         (, uint256 revenueTokenId, uint256 tokenSupply) = assetRegistry.registerAssetAndCreateRevenueTokenPool(
-            vehicleData, assetValue, tokenPrice, block.timestamp + 365 days, 10_000, 1_000, 0, false, false
+            vehicleData, assetValue, tokenPrice, block.timestamp + 365 days, 10_000, 1_000, explicitSupply, false, false
         );
         vm.stopPrank();
 
-        // Verify supply calculation
-        uint256 expectedSupply = assetValue / tokenPrice;
-        assertEq(tokenSupply, expectedSupply, "Supply should match calculated value");
+        assertEq(tokenSupply, explicitSupply, "Supply should match explicit pool size");
 
         assertEq(roboshareTokens.balanceOf(address(marketplace), revenueTokenId), 0);
     }

--- a/web/components/partner/CreateRevenueTokenPoolModal.tsx
+++ b/web/components/partner/CreateRevenueTokenPoolModal.tsx
@@ -55,6 +55,7 @@ export const CreateRevenueTokenPoolModal = ({
   const bufferQuote = calculatePrimaryPoolBuffers(assetValueBigInt, targetYieldBP, formData.protectionEnabled);
   const displayedBufferLabel = formData.protectionEnabled ? "Required Total Buffer" : "Required Protocol Buffer";
   const displayedBufferAmount = formData.protectionEnabled ? bufferQuote.totalBuffer : bufferQuote.protocolBuffer;
+  const requestedSupply = tokenPriceBigInt > 0n ? assetValueBigInt / tokenPriceBigInt : 0n;
 
   const { writeContractAsync: writeVehicleRegistry } = useScaffoldWriteContract({ contractName: "VehicleRegistry" });
 
@@ -147,7 +148,7 @@ export const CreateRevenueTokenPoolModal = ({
           maturityTimestamp,
           revenueShareBP,
           targetYieldBP,
-          0n,
+          requestedSupply,
           formData.immediateProceeds,
           formData.protectionEnabled,
         ],

--- a/web/components/partner/forms/RegisterVehicleForm.tsx
+++ b/web/components/partner/forms/RegisterVehicleForm.tsx
@@ -170,6 +170,7 @@ export const RegisterVehicleForm = ({ onClose, onSuccess, maxStep, onBack }: Reg
   const bufferQuote = calculatePrimaryPoolBuffers(assetValueBigInt, targetYieldBP, formData.protectionEnabled);
   const displayedBufferLabel = formData.protectionEnabled ? "Required Total Buffer" : "Required Protocol Buffer";
   const displayedBufferAmount = formData.protectionEnabled ? bufferQuote.totalBuffer : bufferQuote.protocolBuffer;
+  const requestedSupply = tokenPriceBigInt > 0n ? assetValueBigInt / tokenPriceBigInt : 0n;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -465,7 +466,7 @@ export const RegisterVehicleForm = ({ onClose, onSuccess, maxStep, onBack }: Reg
           maturityTimestamp,
           revenueShareBP,
           targetYieldBP,
-          0n,
+          requestedSupply,
           formData.immediateProceeds,
           formData.protectionEnabled,
         ],


### PR DESCRIPTION
Summary:
- stop deriving pool supply from registry assetValue and require explicit requested supply through the registry/router preview path
- reject zero pool supply and wire the explicit approved supply into revenue token initialization
- update integration coverage and metadata-boundary docs to reflect maxSupply as the authoritative pool-size term

Verification:
- yarn evm:compile
- forge test --offline --match-path test/integration/VehicleRegistry.Integration.t.sol
- forge test --offline --match-path test/integration/RegistryRouter.Integration.t.sol
- git diff --check