### PR TITLE
feat(evm): rewire settlement adapters over manager (ROB-81)

### DIFF
--- a/protocols/evm/contracts/RegistryRouter.sol
+++ b/protocols/evm/contracts/RegistryRouter.sol
@@ -242,11 +242,15 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         }
 
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(assetId);
-        (settlementAmount, settlementPerToken) = ITreasury(treasury).initiateSettlement(partner, assetId, topUpAmount);
+        ITreasury(treasury).initiateSettlement(partner, assetId, topUpAmount);
+        IPositionManager.SettlementState memory settlementState = _getConfiguredSettlementState(assetId);
         IAssetRegistry(idToRegistry[assetId]).setAssetStatus(assetId, AssetLib.AssetStatus.Retired);
 
         // Best-effort: settlement should close primary pool if it exists.
         _closePrimaryPoolIfMarketplaceConfigured(revenueTokenId);
+
+        settlementAmount = settlementState.settlementAmount;
+        settlementPerToken = settlementState.settlementPerToken;
     }
 
     /**
@@ -268,11 +272,15 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         }
 
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(assetId);
-        (liquidationAmount, settlementPerToken) = ITreasury(treasury).executeLiquidation(assetId);
+        ITreasury(treasury).executeLiquidation(assetId);
+        IPositionManager.SettlementState memory settlementState = _getConfiguredSettlementState(assetId);
         IAssetRegistry(idToRegistry[assetId]).setAssetStatus(assetId, AssetLib.AssetStatus.Expired);
 
         // Best-effort: liquidation should close primary pool if it exists.
         _closePrimaryPoolIfMarketplaceConfigured(revenueTokenId);
+
+        liquidationAmount = settlementState.settlementAmount;
+        settlementPerToken = settlementState.settlementPerToken;
     }
 
     /**
@@ -355,20 +363,20 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         IAssetRegistry(registry).liquidateAsset(assetId);
     }
 
-    function claimSettlement(uint256 assetId, bool autoClaimEarnings)
-        external
-        pure
-        override
-        returns (uint256, uint256)
-    {
-        assetId;
-        autoClaimEarnings;
-        revert DirectCallNotAllowed();
+    function claimSettlement(uint256 assetId, bool autoClaimEarnings) external override returns (uint256, uint256) {
+        return _claimSettlementFor(msg.sender, assetId, autoClaimEarnings);
     }
 
     function claimSettlementFor(address account, uint256 assetId, bool autoClaimEarnings)
         external
         override
+        returns (uint256 claimedAmount, uint256 earningsClaimed)
+    {
+        return _claimSettlementFor(account, assetId, autoClaimEarnings);
+    }
+
+    function _claimSettlementFor(address account, uint256 assetId, bool autoClaimEarnings)
+        internal
         returns (uint256 claimedAmount, uint256 earningsClaimed)
     {
         address registry = idToRegistry[assetId];
@@ -482,6 +490,17 @@ contract RegistryRouter is Initializable, AccessControlUpgradeable, UUPSUpgradea
         if (address(manager) == address(0)) revert PositionManagerNotSet();
         if (address(manager).code.length == 0) revert InvalidPositionManager(address(manager));
         return manager;
+    }
+
+    function _getConfiguredSettlementState(uint256 assetId)
+        internal
+        view
+        returns (IPositionManager.SettlementState memory settlementState)
+    {
+        settlementState = _positionManager().getSettlementState(assetId);
+        if (!settlementState.isConfigured) {
+            revert IPositionManager.SettlementNotConfigured(assetId);
+        }
     }
 
     function getRegistryForAsset(uint256 assetId) external view override returns (address) {

--- a/protocols/evm/contracts/VehicleRegistry.sol
+++ b/protocols/evm/contracts/VehicleRegistry.sol
@@ -5,6 +5,7 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { IAssetRegistry } from "./interfaces/IAssetRegistry.sol";
+import { IPositionManager } from "./interfaces/IPositionManager.sol";
 import { TokenLib, AssetLib, VehicleLib } from "./Libraries.sol";
 import { RoboshareTokens } from "./RoboshareTokens.sol";
 import { PartnerManager } from "./PartnerManager.sol";
@@ -33,6 +34,9 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
     error VehicleAlreadyExists();
     error VehicleDoesNotExist();
     error OutstandingTokensHeldByOthers();
+    error PositionManagerNotSet();
+    error InvalidPositionManager(address manager);
+    error SettlementPayoutMismatch(uint256 expected, uint256 actual);
 
     // Events
     event VehicleRegistered(uint256 indexed vehicleId, address indexed partner, bytes32 indexed vinHash);
@@ -305,7 +309,7 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
         override
         returns (uint256 claimedAmount, uint256 earningsClaimed)
     {
-        return _claimSettlementFor(msg.sender, assetId, autoClaimEarnings);
+        return router.claimSettlementFor(msg.sender, assetId, autoClaimEarnings);
     }
 
     /**
@@ -482,6 +486,13 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
             revert InsufficientTokenBalance(revenueTokenId, 1, balance);
         }
 
+        IPositionManager positionManager = _positionManager();
+        IPositionManager.SettlementState memory settlementState = positionManager.getSettlementState(assetId);
+        if (!settlementState.isConfigured) {
+            revert AssetNotSettled(assetId, info.status);
+        }
+        uint256 expectedPayout = positionManager.previewSettlementClaim(assetId, balance);
+
         uint256 snapshotAmount = router.snapshotAndClaimEarnings(assetId, account, autoClaimEarnings);
         if (autoClaimEarnings) {
             earningsClaimed = snapshotAmount;
@@ -489,8 +500,17 @@ contract VehicleRegistry is Initializable, AccessControlUpgradeable, UUPSUpgrade
 
         roboshareTokens.burn(account, revenueTokenId, balance);
         claimedAmount = router.processSettlementClaimFor(account, assetId, balance);
+        if (claimedAmount != expectedPayout) {
+            revert SettlementPayoutMismatch(expectedPayout, claimedAmount);
+        }
 
         emit SettlementClaimed(assetId, account, balance, claimedAmount);
+    }
+
+    function _positionManager() internal view returns (IPositionManager manager) {
+        manager = roboshareTokens.positionManager();
+        if (address(manager) == address(0)) revert PositionManagerNotSet();
+        if (address(manager).code.length == 0) revert InvalidPositionManager(address(manager));
     }
 
     /**

--- a/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
+++ b/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
@@ -5,6 +5,7 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { TreasuryFlowBaseTest } from "../base/TreasuryFlowBaseTest.t.sol";
 import { AssetLib, TokenLib } from "../../contracts/Libraries.sol";
 import { IAssetRegistry } from "../../contracts/interfaces/IAssetRegistry.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 import { Marketplace } from "../../contracts/Marketplace.sol";
 import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
 import { RegistryRouter } from "../../contracts/RegistryRouter.sol";
@@ -499,6 +500,42 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
         vm.prank(unauthorizedRegistry);
         vm.expectRevert(RegistryRouter.RegistryNotBoundToAsset.selector);
         router.processSettlementClaimFor(partner1, assetId, 100);
+    }
+
+    function testInitiateSettlementReturnsManagerSettlementState() public {
+        _ensureState(SetupState.EarningsDistributed);
+        uint256 topUpAmount = SETTLEMENT_TOP_UP_AMOUNT;
+
+        vm.prank(partner1);
+        usdc.approve(address(treasury), topUpAmount);
+
+        vm.prank(address(assetRegistry));
+        (uint256 settlementAmount, uint256 settlementPerToken) =
+            router.initiateSettlement(partner1, scenario.assetId, topUpAmount);
+
+        IPositionManager.SettlementState memory settlementState =
+            roboshareTokens.positionManager().getSettlementState(scenario.assetId);
+        assertTrue(settlementState.isConfigured);
+        assertEq(settlementAmount, settlementState.settlementAmount);
+        assertEq(settlementPerToken, settlementState.settlementPerToken);
+    }
+
+    function testClaimSettlementRoutesThroughRegistry() public {
+        _ensureState(SetupState.EarningsDistributed);
+
+        vm.prank(partner1);
+        assetRegistry.settleAsset(scenario.assetId, 0);
+
+        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
+        uint256 expectedPayout =
+            roboshareTokens.positionManager().previewSettlementClaim(scenario.assetId, buyerBalance);
+
+        vm.prank(buyer);
+        (uint256 claimedAmount, uint256 earningsClaimed) = router.claimSettlement(scenario.assetId, false);
+
+        assertEq(earningsClaimed, 0);
+        assertEq(claimedAmount, expectedPayout);
+        assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), 0);
     }
 
     // TreasuryNotSet Tests

--- a/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
+++ b/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
@@ -910,7 +910,7 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
     }
 
     function testClaimSettlementAssetNotFound() public {
-        vm.expectRevert(abi.encodeWithSelector(IAssetRegistry.AssetNotFound.selector, 999));
+        vm.expectRevert(abi.encodeWithSelector(bytes4(keccak256("RegistryNotFound(uint256)")), 999));
         vm.prank(partner1);
         assetRegistry.claimSettlement(999, false);
     }
@@ -943,6 +943,28 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         );
 
         assetRegistry.claimSettlement(scenario.assetId, false);
+    }
+
+    function testClaimSettlementTracksManagerPayout() public {
+        _ensureState(SetupState.EarningsDistributed);
+
+        vm.prank(partner1);
+        assetRegistry.settleAsset(scenario.assetId, 0);
+
+        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
+        uint256 expectedPayout = _positionManager().previewSettlementClaim(scenario.assetId, buyerBalance);
+
+        vm.prank(buyer);
+        (uint256 claimedAmount, uint256 earningsClaimed) = assetRegistry.claimSettlement(scenario.assetId, false);
+
+        assertEq(earningsClaimed, 0);
+        assertEq(claimedAmount, expectedPayout);
+        assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), 0);
+
+        IPositionManager.SettlementClaimState memory claimState =
+            _positionManager().getSettlementClaimState(scenario.assetId, buyer);
+        assertEq(claimState.burnedAmount, buyerBalance);
+        assertEq(claimState.payout, claimedAmount);
     }
 
     function testClaimSettlementForUnauthorizedCaller() public {

--- a/protocols/evm/test/unit/RegistryRouter.t.sol
+++ b/protocols/evm/test/unit/RegistryRouter.t.sol
@@ -221,8 +221,8 @@ contract RegistryRouterTest is AssetMetadataBaseTest {
         );
     }
 
-    function testClaimSettlementDirectCallNotAllowed() public {
-        vm.expectRevert(RegistryRouter.DirectCallNotAllowed.selector);
+    function testClaimSettlementRegistryNotFound() public {
+        vm.expectRevert(abi.encodeWithSelector(RegistryRouter.RegistryNotFound.selector, uint256(0)));
         router.claimSettlement(scenario.assetId, false);
     }
 


### PR DESCRIPTION
Summary:
- make RegistryRouter a real settlement-claim adapter over manager-backed settlement state
- move VehicleRegistry settlement claims through the router and validate expected payout against PositionManager before treasury claim finalization
- extend router and vehicle integration coverage for manager-backed settlement state and claim payout tracking

Verification:
- forge test --offline --match-path test/integration/RegistryRouter.Integration.t.sol
- forge test --offline --match-path test/integration/VehicleRegistry.Integration.t.sol
- git diff --check