### PR TITLE
feat(evm): rewire marketplace manager views (ROB-80)

### DIFF
--- a/protocols/evm/contracts/Marketplace.sol
+++ b/protocols/evm/contracts/Marketplace.sol
@@ -315,10 +315,11 @@ contract Marketplace is
         returns (uint256 payout, uint256 investorLiquidity, uint256 redemptionSupply, uint256 holderEligibleBalance)
     {
         _getPrimaryPool(tokenId);
-        holderEligibleBalance = roboshareTokens.getPrimaryRedemptionEligibleBalance(holder, tokenId);
+        IPositionManager manager = _positionManager();
+        holderEligibleBalance = manager.getPrimaryRedemptionEligibleBalance(holder, tokenId);
         if (amount == 0) return (0, 0, 0, holderEligibleBalance);
 
-        redemptionSupply = roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId);
+        redemptionSupply = manager.getCurrentPrimaryRedemptionEpochSupply(tokenId);
         uint256 assetId = TokenLib.getAssetIdFromTokenId(tokenId);
         (, investorLiquidity,,,,,,,,,) = treasury.assetCollateral(assetId);
         if (amount > holderEligibleBalance || redemptionSupply == 0 || investorLiquidity == 0) {
@@ -367,10 +368,9 @@ contract Marketplace is
         if (amount == 0 || amount > tokenSupply) revert InvalidAmount();
 
         uint256 sellerBalance = roboshareTokens.balanceOf(seller, tokenId);
-        uint256 earlySalePenalty = 0;
-
         if (sellerBalance < amount) revert InsufficientTokenBalance();
-        earlySalePenalty = roboshareTokens.getSalesPenalty(seller, tokenId, amount);
+        IPositionManager manager = _positionManager();
+        uint256 earlySalePenalty = manager.getSalesPenalty(seller, tokenId, amount);
 
         listingId = _listingIdCounter++;
         uint256 expiresAt = block.timestamp + duration;
@@ -390,7 +390,8 @@ contract Marketplace is
         });
 
         assetListings[assetId].push(listingId);
-        _positionManager().lockForListing(seller, tokenId, amount);
+        manager.lockForListing(seller, tokenId, amount);
+        manager.bookSalePenalty(listingId, seller, tokenId, earlySalePenalty);
 
         emit ListingCreated(listingId, tokenId, assetId, seller, amount, pricePerToken, expiresAt, buyerPaysFee);
         return listingId;
@@ -432,7 +433,9 @@ contract Marketplace is
         listing.isActive = false;
 
         if (listing.amount > 0) {
-            _positionManager().unlockForListing(listing.seller, listing.tokenId, listing.amount);
+            IPositionManager manager = _positionManager();
+            manager.unlockForListing(listing.seller, listing.tokenId, listing.amount);
+            manager.clearSalePenalty(listingId);
             listing.amount = 0;
         }
 
@@ -647,7 +650,7 @@ contract Marketplace is
     {
         quote.grossProceeds = amount * listing.pricePerToken;
         quote.protocolFee = ProtocolLib.calculateProtocolFee(quote.grossProceeds);
-        quote.earlySalePenalty = roboshareTokens.getSalesPenalty(listing.seller, listing.tokenId, amount);
+        quote.earlySalePenalty = _positionManager().getSalesPenalty(listing.seller, listing.tokenId, amount);
 
         if (listing.buyerPaysFee) {
             if (quote.earlySalePenalty > quote.grossProceeds) revert FeesExceedPrice();
@@ -686,6 +689,7 @@ contract Marketplace is
         listing.soldAmount += amount;
         if (listing.amount == 0) {
             listing.isActive = false;
+            _positionManager().clearSalePenalty(listingId);
         }
 
         if (quote.sellerNet > 0) {
@@ -703,7 +707,9 @@ contract Marketplace is
 
         listing.isActive = false;
         if (listing.amount > 0) {
-            _positionManager().unlockForListing(listing.seller, listing.tokenId, listing.amount);
+            IPositionManager manager = _positionManager();
+            manager.unlockForListing(listing.seller, listing.tokenId, listing.amount);
+            manager.clearSalePenalty(listing.listingId);
             listing.amount = 0;
         }
         return true;

--- a/protocols/evm/test/integration/Marketplace.Integration.t.sol
+++ b/protocols/evm/test/integration/Marketplace.Integration.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.19;
 
 import { AssetLib, ProtocolLib } from "../../contracts/Libraries.sol";
+import { IPositionManager } from "../../contracts/interfaces/IPositionManager.sol";
 import { MarketplaceFlowBaseTest } from "../base/MarketplaceFlowBaseTest.t.sol";
 import { Marketplace } from "../../contracts/Marketplace.sol";
 import { PartnerManager } from "../../contracts/PartnerManager.sol";
@@ -592,12 +593,15 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
     function testPrimaryRedemptionPreviewAndRedeem() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
         uint256 burnAmount = PRIMARY_PURCHASE_AMOUNT / 2;
+        IPositionManager manager = roboshareTokens.positionManager();
 
         (uint256 previewPayout,, uint256 redemptionSupply, uint256 eligibleBalance) =
             marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, burnAmount);
         assertGt(previewPayout, 0);
         assertGt(redemptionSupply, 0);
         assertGe(eligibleBalance, burnAmount);
+        assertEq(redemptionSupply, manager.getCurrentPrimaryRedemptionEpochSupply(scenario.revenueTokenId));
+        assertEq(eligibleBalance, manager.getPrimaryRedemptionEligibleBalance(buyer, scenario.revenueTokenId));
 
         uint256 buyerUsdcBefore = usdc.balanceOf(buyer);
         uint256 buyerTokensBefore = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
@@ -696,6 +700,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
     function testEndListing() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
+        IPositionManager manager = roboshareTokens.positionManager();
 
         uint256 buyerBalance = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
         vm.startPrank(buyer);
@@ -717,10 +722,12 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
         assertEq(lockedBefore, buyerBefore);
         assertEq(lockedAfter, 0);
         assertEq(buyerAfter, buyerBefore);
+        assertEq(manager.getSalePenalty(listingId), 0);
     }
 
     function testCreateListingSetsEarlySalePenalty() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
+        IPositionManager manager = roboshareTokens.positionManager();
         vm.startPrank(buyer);
         roboshareTokens.setApprovalForAll(address(marketplace), true);
         uint256 secondaryListingId = marketplace.createListing(
@@ -730,6 +737,14 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
         Marketplace.Listing memory listing = marketplace.getListing(secondaryListingId);
         assertGt(listing.earlySalePenalty, 0, "Early sale penalty should be set");
+        assertEq(
+            listing.earlySalePenalty,
+            manager.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT),
+            "Listing penalty should mirror PositionManager at listing time"
+        );
+        assertEq(
+            manager.getSalePenalty(secondaryListingId), listing.earlySalePenalty, "Manager snapshot penalty mismatch"
+        );
     }
 
     // Purchase Listing Tests
@@ -792,9 +807,9 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
     function testBuyFromSecondaryListingEarlySalePenalty() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
+        IPositionManager manager = roboshareTokens.positionManager();
 
-        uint256 earlySalePenalty =
-            roboshareTokens.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
+        uint256 earlySalePenalty = manager.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
         assertGt(earlySalePenalty, 0, "Sales penalty should be greater than zero");
 
         vm.startPrank(buyer);
@@ -808,7 +823,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
         (uint256 totalPrice, uint256 protocolFee, uint256 expectedPayment) =
             marketplace.previewSecondaryPurchase(newListingId, SECONDARY_PURCHASE_AMOUNT);
 
-        uint256 fillPenalty = roboshareTokens.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
+        uint256 fillPenalty = manager.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
         assertEq(fillPenalty, earlySalePenalty, "Fill penalty mismatch");
 
         // 4. Partner purchases the tokens
@@ -843,6 +858,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
     function testBuyFromSecondaryListingSellerPaysFee() public {
         _ensureSecondaryListingScenario();
+        IPositionManager manager = roboshareTokens.positionManager();
 
         // Create a secondary listing with seller paying the fee
         uint256 newListingId = _setupSecondaryListing(partner2, SECONDARY_PURCHASE_AMOUNT, REVENUE_TOKEN_PRICE, false);
@@ -850,8 +866,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
         (uint256 totalPrice, uint256 protocolFee, uint256 expectedPayment) =
             marketplace.previewSecondaryPurchase(newListingId, SECONDARY_PURCHASE_AMOUNT);
         uint256 sellerReceives = totalPrice - protocolFee;
-        uint256 fillPenalty =
-            roboshareTokens.getSalesPenalty(partner2, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
+        uint256 fillPenalty = manager.getSalesPenalty(partner2, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
 
         vm.startPrank(buyer);
         usdc.approve(address(marketplace), expectedPayment);
@@ -885,6 +900,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
     function testBuyFromSecondaryListingUsesFillTimePenaltyAfterHoldingPeriod() public {
         _ensureState(SetupState.PurchasedFromPrimaryPool);
+        IPositionManager manager = roboshareTokens.positionManager();
 
         vm.startPrank(buyer);
         roboshareTokens.setApprovalForAll(address(marketplace), true);
@@ -898,7 +914,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
         _warpPastHoldingPeriod();
 
-        uint256 fillPenalty = roboshareTokens.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
+        uint256 fillPenalty = manager.getSalesPenalty(buyer, scenario.revenueTokenId, SECONDARY_PURCHASE_AMOUNT);
         assertEq(fillPenalty, 0, "Fill-time penalty should decay to zero after holding period");
 
         (uint256 totalPrice, uint256 protocolFee, uint256 expectedPayment) =

--- a/protocols/evm/test/unit/Marketplace.t.sol
+++ b/protocols/evm/test/unit/Marketplace.t.sol
@@ -91,6 +91,59 @@ contract MarketplaceRoboshareTokensStub {
     }
 }
 
+contract MarketplacePositionManagerStub {
+    uint256 internal _penalty;
+    uint256 internal _eligibleBalance;
+    uint256 internal _redemptionSupply;
+    address internal _lastLockHolder;
+    uint256 internal _lastLockTokenId;
+    uint256 internal _lastLockAmount;
+    mapping(uint256 => uint256) internal _listingPenalties;
+
+    function setSalesPenalty(uint256 penalty) external {
+        _penalty = penalty;
+    }
+
+    function setRedemptionPreview(uint256 eligibleBalance, uint256 redemptionSupply) external {
+        _eligibleBalance = eligibleBalance;
+        _redemptionSupply = redemptionSupply;
+    }
+
+    function getSalesPenalty(address, uint256, uint256) external view returns (uint256) {
+        return _penalty;
+    }
+
+    function getPrimaryRedemptionEligibleBalance(address, uint256) external view returns (uint256) {
+        return _eligibleBalance;
+    }
+
+    function getCurrentPrimaryRedemptionEpochSupply(uint256) external view returns (uint256) {
+        return _redemptionSupply;
+    }
+
+    function lockForListing(address holder, uint256 tokenId, uint256 amount) external {
+        _lastLockHolder = holder;
+        _lastLockTokenId = tokenId;
+        _lastLockAmount = amount;
+    }
+
+    function getLastLock() external view returns (address holder, uint256 tokenId, uint256 amount) {
+        return (_lastLockHolder, _lastLockTokenId, _lastLockAmount);
+    }
+
+    function bookSalePenalty(uint256 listingId, address, uint256, uint256 amount) external {
+        _listingPenalties[listingId] = amount;
+    }
+
+    function clearSalePenalty(uint256 listingId) external {
+        delete _listingPenalties[listingId];
+    }
+
+    function getSalePenalty(uint256 listingId) external view returns (uint256) {
+        return _listingPenalties[listingId];
+    }
+}
+
 contract MarketplaceTest is AssetMetadataBaseTest {
     function _setupBuffersFunded() internal override { }
 
@@ -408,6 +461,36 @@ contract MarketplaceTest is AssetMetadataBaseTest {
         );
     }
 
+    function testCreateListingUsesPositionManagerPenaltyAndLocking() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        MarketplaceRoboshareTokensStub tokenStub = new MarketplaceRoboshareTokensStub();
+        MarketplacePositionManagerStub managerStub = new MarketplacePositionManagerStub();
+
+        tokenStub.setPositionManager(address(managerStub));
+        tokenStub.setRevenueTokenSupply(SECONDARY_LISTING_AMOUNT);
+        tokenStub.setSalesPenalty(17e6);
+        tokenStub.setBalance(partner1, scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT);
+        managerStub.setSalesPenalty(23e6);
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(tokenStub));
+
+        vm.prank(partner1);
+        uint256 listingId = marketplace.createListing(
+            scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT, REVENUE_TOKEN_PRICE, LISTING_DURATION, true
+        );
+
+        Marketplace.Listing memory listing = marketplace.getListing(listingId);
+        assertEq(listing.earlySalePenalty, 23e6);
+        assertEq(managerStub.getSalePenalty(listingId), 23e6);
+
+        (address lockedHolder, uint256 lockedTokenId, uint256 lockedAmount) = managerStub.getLastLock();
+        assertEq(lockedHolder, partner1);
+        assertEq(lockedTokenId, scenario.revenueTokenId);
+        assertEq(lockedAmount, SECONDARY_LISTING_AMOUNT);
+    }
+
     function testBuyFromSecondaryListingRevertsWhenPositionManagerIsNotContract() public {
         _ensureState(SetupState.PrimaryPoolCreated);
         _purchasePrimaryPoolTokens(partner1, scenario.revenueTokenId, SECONDARY_LISTING_AMOUNT);
@@ -434,6 +517,53 @@ contract MarketplaceTest is AssetMetadataBaseTest {
         vm.stopPrank();
 
         assertEq(usdc.balanceOf(buyer), buyerUsdcBefore);
+    }
+
+    function testPreviewPrimaryRedemptionRevertsWhenPositionManagerUnset() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        MarketplaceRoboshareTokensStub stub = new MarketplaceRoboshareTokensStub();
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(stub));
+
+        vm.expectRevert(Marketplace.PositionManagerNotSet.selector);
+        marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, 1);
+    }
+
+    function testPreviewPrimaryRedemptionRevertsWhenPositionManagerIsNotContract() public {
+        _ensureState(SetupState.PrimaryPoolCreated);
+
+        MarketplaceRoboshareTokensStub stub = new MarketplaceRoboshareTokensStub();
+        stub.setPositionManager(unauthorized);
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(stub));
+
+        vm.expectRevert(abi.encodeWithSelector(Marketplace.InvalidPositionManager.selector, unauthorized));
+        marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, 1);
+    }
+
+    function testPreviewPrimaryRedemptionUsesPositionManagerViews() public {
+        _ensureState(SetupState.PurchasedFromPrimaryPool);
+
+        MarketplaceRoboshareTokensStub tokenStub = new MarketplaceRoboshareTokensStub();
+        MarketplacePositionManagerStub managerStub = new MarketplacePositionManagerStub();
+
+        tokenStub.setPositionManager(address(managerStub));
+        managerStub.setRedemptionPreview(PRIMARY_PURCHASE_AMOUNT, PRIMARY_PURCHASE_AMOUNT);
+
+        vm.prank(admin);
+        marketplace.updateRoboshareTokens(address(tokenStub));
+
+        (, uint256 investorLiquidity,,,,,,,,,) = treasury.assetCollateral(scenario.assetId);
+
+        (uint256 payout,, uint256 redemptionSupply, uint256 eligibleBalance) =
+            marketplace.previewPrimaryRedemption(scenario.revenueTokenId, buyer, PRIMARY_PURCHASE_AMOUNT);
+
+        assertEq(payout, investorLiquidity);
+        assertEq(redemptionSupply, PRIMARY_PURCHASE_AMOUNT);
+        assertEq(eligibleBalance, PRIMARY_PURCHASE_AMOUNT);
     }
 
     function testUpdateTreasury() public {


### PR DESCRIPTION
Summary:
- route Marketplace primary redemption preview state through PositionManager views instead of token-owned wrappers
- use PositionManager for listing-time and fill-time sale-penalty reads and wire manager-side penalty snapshot bookkeeping through listing lifecycle events
- extend marketplace unit and integration coverage for manager-routed listing locks, penalties, and redemption previews

Verification:
- forge test --offline --match-path test/unit/Marketplace.t.sol
- forge test --offline --match-path test/integration/Marketplace.Integration.t.sol
- git diff --check