### PR TITLE
feat(evm): wire position manager in deploy flow (ROB-83)

### DIFF
--- a/protocols/evm/script/Deploy.s.sol
+++ b/protocols/evm/script/Deploy.s.sol
@@ -10,6 +10,7 @@ import { VehicleRegistry } from "../contracts/VehicleRegistry.sol";
 import { Treasury } from "../contracts/Treasury.sol";
 import { EarningsManager } from "../contracts/EarningsManager.sol";
 import { Marketplace } from "../contracts/Marketplace.sol";
+import { PositionManager } from "../contracts/PositionManager.sol";
 
 /**
  * @title Deploy
@@ -26,7 +27,8 @@ contract Deploy is DeployCore {
             VehicleRegistry vehicleRegistry,
             Treasury treasury,
             EarningsManager earningsManager,
-            Marketplace marketplace
+            Marketplace marketplace,
+            PositionManager positionManager
         )
     {
         // Get network configuration
@@ -62,6 +64,7 @@ contract Deploy is DeployCore {
         treasury = contracts.treasury;
         earningsManager = contracts.earningsManager;
         marketplace = contracts.marketplace;
+        positionManager = contracts.positionManager;
 
         // Save deployments for frontend generation
         saveDeployment("RoboshareTokens", address(roboshareTokens));
@@ -71,6 +74,7 @@ contract Deploy is DeployCore {
         saveDeployment("Treasury", address(treasury));
         saveDeployment("EarningsManager", address(earningsManager));
         saveDeployment("Marketplace", address(marketplace));
+        saveDeployment("PositionManager", address(positionManager));
 
         // Save MockUSDC deployment for test networks
         if (isLocalOrTestNetwork() && config.usdcToken != address(0)) {

--- a/protocols/evm/script/DeployCore.s.sol
+++ b/protocols/evm/script/DeployCore.s.sol
@@ -10,6 +10,7 @@ import { VehicleRegistry } from "../contracts/VehicleRegistry.sol";
 import { Treasury } from "../contracts/Treasury.sol";
 import { EarningsManager } from "../contracts/EarningsManager.sol";
 import { Marketplace } from "../contracts/Marketplace.sol";
+import { PositionManager } from "../contracts/PositionManager.sol";
 
 /**
  * @title DeployCore
@@ -25,6 +26,7 @@ abstract contract DeployCore is ScaffoldETHDeploy {
         Treasury treasury;
         EarningsManager earningsManager;
         Marketplace marketplace;
+        PositionManager positionManager;
     }
 
     /**
@@ -129,6 +131,24 @@ abstract contract DeployCore is ScaffoldETHDeploy {
             contracts.marketplace = Marketplace(address(marketplaceProxy));
         }
 
+        // Deploy PositionManager
+        {
+            PositionManager positionManagerImplementation = new PositionManager();
+            bytes memory positionManagerInitData = abi.encodeWithSignature(
+                "initialize(address,address,address,address,address,address,address)",
+                _deployer,
+                address(contracts.router),
+                address(contracts.roboshareTokens),
+                address(contracts.partnerManager),
+                address(contracts.marketplace),
+                address(contracts.treasury),
+                config.usdcToken
+            );
+            ERC1967Proxy positionManagerProxy =
+                new ERC1967Proxy(address(positionManagerImplementation), positionManagerInitData);
+            contracts.positionManager = PositionManager(address(positionManagerProxy));
+        }
+
         // --- Configuration & Role Granting ---
         _configureRoles(contracts);
     }
@@ -143,6 +163,7 @@ abstract contract DeployCore is ScaffoldETHDeploy {
         contracts.router.setEarningsManager(address(contracts.earningsManager));
         contracts.router.setMarketplace(address(contracts.marketplace));
         contracts.treasury.setEarningsManager(address(contracts.earningsManager));
+        contracts.roboshareTokens.setPositionManager(address(contracts.positionManager));
 
         // 2. Grant Roles
         // Grant AUTHORIZED_REGISTRY_ROLE to VehicleRegistry

--- a/protocols/evm/script/DeployForTest.s.sol
+++ b/protocols/evm/script/DeployForTest.s.sol
@@ -9,6 +9,7 @@ import { VehicleRegistry } from "../contracts/VehicleRegistry.sol";
 import { Treasury } from "../contracts/Treasury.sol";
 import { EarningsManager } from "../contracts/EarningsManager.sol";
 import { Marketplace } from "../contracts/Marketplace.sol";
+import { PositionManager } from "../contracts/PositionManager.sol";
 
 /**
  * @title DeployForTest
@@ -32,7 +33,8 @@ contract DeployForTest is DeployCore {
             VehicleRegistry vehicleRegistry,
             Treasury treasury,
             EarningsManager earningsManager,
-            Marketplace marketplace
+            Marketplace marketplace,
+            PositionManager positionManager
         )
     {
         // Get network configuration
@@ -62,5 +64,6 @@ contract DeployForTest is DeployCore {
         treasury = contracts.treasury;
         earningsManager = contracts.earningsManager;
         marketplace = contracts.marketplace;
+        positionManager = contracts.positionManager;
     }
 }

--- a/protocols/evm/test/base/BaseTest.t.sol
+++ b/protocols/evm/test/base/BaseTest.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import { Test } from "forge-std/Test.sol";
-import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { PositionManager } from "../../contracts/PositionManager.sol";
 import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
@@ -36,6 +35,7 @@ abstract contract BaseTest is Test {
     RegistryRouter public router;
     VehicleRegistry public assetRegistry;
     Marketplace public marketplace;
+    PositionManager public positionManager;
     IERC20 public usdc;
 
     DeployForTest.NetworkConfig public config;
@@ -112,15 +112,19 @@ abstract contract BaseTest is Test {
 
     function _deployContracts() internal {
         deployer = new DeployForTest();
-        (roboshareTokens, partnerManager, router, assetRegistry, treasury, earningsManager, marketplace) =
-            deployer.run(admin);
+        (
+            roboshareTokens,
+            partnerManager,
+            router,
+            assetRegistry,
+            treasury,
+            earningsManager,
+            marketplace,
+            positionManager
+        ) = deployer.run(admin);
 
         config = deployer.getActiveNetworkConfig();
         usdc = IERC20(config.usdcToken);
-
-        PositionManager positionManager = _deployPositionManager();
-        vm.prank(admin);
-        roboshareTokens.setPositionManager(address(positionManager));
     }
 
     function _setupInitialRolesAndAccounts() internal {
@@ -144,27 +148,6 @@ abstract contract BaseTest is Test {
 
     function _fundAddressWithUsdc(address account, uint256 amount) internal {
         deal(address(usdc), account, amount);
-    }
-
-    function _deployPositionManager() internal returns (PositionManager) {
-        PositionManager implementation = new PositionManager();
-        ERC1967Proxy proxy = new ERC1967Proxy(
-            address(implementation),
-            abi.encodeCall(
-                PositionManager.initialize,
-                (
-                    admin,
-                    address(router),
-                    address(roboshareTokens),
-                    address(partnerManager),
-                    address(marketplace),
-                    address(treasury),
-                    address(usdc)
-                )
-            )
-        );
-
-        return PositionManager(address(proxy));
     }
 
     function _setupAssetRegistered() internal virtual returns (uint256);


### PR DESCRIPTION
Summary
- deploy PositionManager in the shared core flow and attach it through RoboshareTokens
- return and save the deployed manager from the main deploy entrypoints
- remove the old test-only manual manager bootstrap from BaseTest

Verification
- forge test --offline --match-path test/integration/Marketplace.Integration.t.sol