### PR TITLE
feat(web): rewire manager-backed reads in markets (ROB-84)

### DIFF
--- a/web/app/markets/page.tsx
+++ b/web/app/markets/page.tsx
@@ -28,6 +28,13 @@ import { usePaymentToken } from "~~/hooks/usePaymentToken";
 import { useTransactingAccount } from "~~/hooks/useTransactingAccount";
 import { getDeployedContract } from "~~/utils/contracts";
 import { fetchIpfsMetadata, ipfsToHttp } from "~~/utils/ipfsGateway";
+import {
+  POSITION_MANAGER_PRIMARY_REDEMPTION_READER_ABI,
+  ROBOSHARE_TOKENS_MANAGER_READER_ABI,
+  normalizePositionManagerAddress,
+  normalizePrimaryRedemptionPreview,
+  normalizeVehicleMetadata,
+} from "~~/utils/protocolState";
 import { getTargetNetworks, notification } from "~~/utils/scaffold-eth";
 import { getSubgraphQueryUrl } from "~~/utils/subgraph";
 
@@ -225,6 +232,13 @@ const MarketsPage: NextPage = () => {
   const { symbol, decimals } = usePaymentToken();
   const { writeContractAsync: writeTreasury } = useScaffoldWriteContract({ contractName: "Treasury" });
   const { writeContractAsync: writeEarningsManager } = useScaffoldWriteContract({ contractName: "EarningsManager" });
+  const { data: positionManagerAddressData } = useReadContract({
+    address: roboshareTokensContract?.address,
+    abi: ROBOSHARE_TOKENS_MANAGER_READER_ABI,
+    functionName: "positionManager",
+    query: { enabled: !!roboshareTokensContract },
+  });
+  const positionManagerAddress = normalizePositionManagerAddress(positionManagerAddressData);
 
   const getVehicleImageKey = useCallback(
     (vehicle: Pick<SubgraphVehicle, "id" | "metadataURI">) => `${chainId}:${vehicle.id}:${vehicle.metadataURI || ""}`,
@@ -263,16 +277,7 @@ const MarketsPage: NextPage = () => {
         return vehicle;
       }
 
-      const info = result.result;
-      const liveYear = info[3];
-      return {
-        ...vehicle,
-        vin: (info[0] as string | undefined) || vehicle.vin,
-        make: (info[1] as string | undefined) || vehicle.make,
-        model: (info[2] as string | undefined) || vehicle.model,
-        year: liveYear !== undefined && liveYear !== null ? String(liveYear as bigint | number | string) : vehicle.year,
-        metadataURI: (info[6] as string | undefined) || vehicle.metadataURI,
-      };
+      return normalizeVehicleMetadata(result.result, vehicle);
     });
   }, [vehicleInfoData, vehicles]);
 
@@ -486,15 +491,15 @@ const MarketsPage: NextPage = () => {
 
   const { data: primaryPoolEligibleRedemptionData, refetch: refetchPrimaryPoolEligibleRedemptionBalances } =
     useReadContracts({
-      contracts: roboshareTokensContract
+      contracts: positionManagerAddress
         ? primaryPools.map(pool => ({
-            address: roboshareTokensContract.address,
-            abi: roboshareTokensContract.abi,
+            address: positionManagerAddress,
+            abi: POSITION_MANAGER_PRIMARY_REDEMPTION_READER_ABI,
             functionName: "getPrimaryRedemptionEligibleBalance",
             args: [address, BigInt(pool.tokenId)],
           }))
         : ([] as any),
-      query: { enabled: !!address && !!roboshareTokensContract && primaryPools.length > 0 },
+      query: { enabled: !!address && !!positionManagerAddress && primaryPools.length > 0 },
     });
 
   const { data: primaryPoolRedemptionPreviewData, refetch: refetchPrimaryPoolRedemptionPreviews } = useReadContracts({
@@ -670,17 +675,16 @@ const MarketsPage: NextPage = () => {
     >();
     primaryPools.forEach((pool, index) => {
       const result = primaryPoolRedemptionPreviewData?.[index];
-      if (result?.status !== "success" || !Array.isArray(result.result)) {
-        const eligibleResult = primaryPoolEligibleRedemptionData?.[index];
-        const eligibleBalance =
-          eligibleResult?.status === "success" && eligibleResult.result !== undefined
-            ? (eligibleResult.result as bigint)
-            : 0n;
-        byTokenId.set(pool.tokenId, { payout: 0n, liquidity: 0n, redemptionSupply: 0n, eligibleBalance });
-        return;
-      }
-      const [payout, liquidity, redemptionSupply, eligibleBalance] = result.result as [bigint, bigint, bigint, bigint];
-      byTokenId.set(pool.tokenId, { payout, liquidity, redemptionSupply, eligibleBalance });
+      const eligibleResult = primaryPoolEligibleRedemptionData?.[index];
+      const eligibleBalance =
+        eligibleResult?.status === "success" && eligibleResult.result !== undefined
+          ? (eligibleResult.result as bigint)
+          : 0n;
+      const preview =
+        result?.status === "success"
+          ? normalizePrimaryRedemptionPreview(result.result, eligibleBalance)
+          : normalizePrimaryRedemptionPreview(undefined, eligibleBalance);
+      byTokenId.set(pool.tokenId, preview);
     });
     return byTokenId;
   }, [primaryPoolEligibleRedemptionData, primaryPools, primaryPoolRedemptionPreviewData]);

--- a/web/app/partner/page.tsx
+++ b/web/app/partner/page.tsx
@@ -21,6 +21,7 @@ import { usePaymentToken } from "~~/hooks/usePaymentToken";
 import { useTransactingAccount } from "~~/hooks/useTransactingAccount";
 import { getDeployedContract } from "~~/utils/contracts";
 import { fetchIpfsMetadata, ipfsToHttp } from "~~/utils/ipfsGateway";
+import { normalizeVehicleMetadata } from "~~/utils/protocolState";
 import { getTargetNetworks, notification } from "~~/utils/scaffold-eth";
 import { getSubgraphQueryUrl } from "~~/utils/subgraph";
 
@@ -327,16 +328,7 @@ const PartnerDashboard: NextPage = () => {
         return asset;
       }
 
-      const info = result.result;
-      const liveYear = info[3];
-      return {
-        ...asset,
-        vin: (info[0] as string | undefined) || asset.vin,
-        make: (info[1] as string | undefined) || asset.make,
-        model: (info[2] as string | undefined) || asset.model,
-        year: liveYear !== undefined && liveYear !== null ? String(liveYear as bigint | number | string) : asset.year,
-        metadataURI: (info[6] as string | undefined) || asset.metadataURI,
-      };
+      return normalizeVehicleMetadata(result.result, asset);
     });
   }, [allAssets, assetMetadataData]);
 

--- a/web/components/markets/RedeemLiquidityModal.tsx
+++ b/web/components/markets/RedeemLiquidityModal.tsx
@@ -13,6 +13,7 @@ import { useTransactingAccount } from "~~/hooks/useTransactingAccount";
 import { isPrivyEnabled } from "~~/services/web3/privyConfig";
 import { getPrivyIdentityLabel } from "~~/services/web3/privyIdentity";
 import { getDeployedContract } from "~~/utils/contracts";
+import { normalizePrimaryRedemptionPreview } from "~~/utils/protocolState";
 
 interface RedeemLiquidityModalProps {
   isOpen: boolean;
@@ -200,12 +201,10 @@ export function RedeemLiquidityModal({
     contractName: "Marketplace",
   });
 
-  const fullPositionPreviewTuple = fullPositionRedemptionPreview as
-    | readonly [bigint, bigint, bigint, bigint]
-    | undefined;
-  const fullPositionPayout = fullPositionPreviewTuple?.[0] ?? 0n;
-  const availableLiquidityNow = fullPositionPreviewTuple?.[1] ?? 0n;
-  const withdrawableSupplyNow = fullPositionPreviewTuple?.[2] ?? 0n;
+  const fullPositionPreview = normalizePrimaryRedemptionPreview(fullPositionRedemptionPreview);
+  const fullPositionPayout = fullPositionPreview.payout;
+  const availableLiquidityNow = fullPositionPreview.liquidity;
+  const withdrawableSupplyNow = fullPositionPreview.redemptionSupply;
   const maxFunds = fullPositionPayout;
   const totalPositionValue = totalPosition * pricePerUnit;
   const enteredFunds = useMemo(() => {
@@ -227,8 +226,7 @@ export function RedeemLiquidityModal({
     args: address ? [BigInt(tokenId), address, redeemAmount] : undefined,
     query: { enabled: isOpen && !!address && !!marketplaceContract },
   });
-  const previewTuple = redemptionPreview as readonly [bigint, bigint, bigint, bigint] | undefined;
-  const payout = previewTuple?.[0] ?? 0n;
+  const payout = normalizePrimaryRedemptionPreview(redemptionPreview).payout;
   const formattedFullPositionPayout = formatUnits(fullPositionPayout, decimals);
   const formattedTotalPositionValue = formatUnits(totalPositionValue, decimals);
   const formattedAvailableLiquidityNow = formatUnits(availableLiquidityNow, decimals);

--- a/web/utils/protocolState.ts
+++ b/web/utils/protocolState.ts
@@ -1,0 +1,97 @@
+import { type Address } from "viem";
+
+export const ROBOSHARE_TOKENS_MANAGER_READER_ABI = [
+  {
+    type: "function",
+    name: "positionManager",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;
+
+export const POSITION_MANAGER_PRIMARY_REDEMPTION_READER_ABI = [
+  {
+    type: "function",
+    name: "getPrimaryRedemptionEligibleBalance",
+    stateMutability: "view",
+    inputs: [
+      { name: "holder", type: "address" },
+      { name: "revenueTokenId", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+type VehicleMetadataFallback = {
+  vin?: string;
+  make?: string;
+  model?: string;
+  year?: string | bigint;
+  metadataURI?: string;
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const asDisplayYear = (value: unknown): string | undefined => {
+  if (typeof value === "bigint" || typeof value === "number" || typeof value === "string") {
+    return String(value);
+  }
+
+  return undefined;
+};
+
+export const normalizeVehicleMetadata = <TFallback extends VehicleMetadataFallback>(
+  result: readonly unknown[] | undefined,
+  fallback: TFallback,
+): TFallback => {
+  if (!Array.isArray(result) || result.length === 0) {
+    return fallback;
+  }
+
+  // New contract shape: [vinHash, assetMetadataURI, revenueTokenMetadataURI]
+  if (result.length <= 3) {
+    return {
+      ...fallback,
+      metadataURI: asString(result[1]) || fallback.metadataURI,
+    } as TFallback;
+  }
+
+  // Legacy/generated helper shape kept here to tolerate stale frontend artifacts while the web app migrates.
+  return {
+    ...fallback,
+    vin: asString(result[0]) || fallback.vin,
+    make: asString(result[1]) || fallback.make,
+    model: asString(result[2]) || fallback.model,
+    year: asDisplayYear(result[3]) || fallback.year,
+    metadataURI: asString(result[6]) || fallback.metadataURI,
+  } as TFallback;
+};
+
+export const normalizePrimaryRedemptionPreview = (result: unknown, fallbackEligibleBalance = 0n) => {
+  if (!Array.isArray(result)) {
+    return {
+      payout: 0n,
+      liquidity: 0n,
+      redemptionSupply: 0n,
+      eligibleBalance: fallbackEligibleBalance,
+    };
+  }
+
+  return {
+    payout: (result[0] as bigint | undefined) ?? 0n,
+    liquidity: (result[1] as bigint | undefined) ?? 0n,
+    redemptionSupply: (result[2] as bigint | undefined) ?? 0n,
+    eligibleBalance: (result[3] as bigint | undefined) ?? fallbackEligibleBalance,
+  };
+};
+
+export const normalizePositionManagerAddress = (value: unknown): Address | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value as Address;
+  return normalized === "0x0000000000000000000000000000000000000000" ? undefined : normalized;
+};


### PR DESCRIPTION
Summary
- route primary redemption eligibility reads through PositionManager-owned surfaces
- centralize vehicle metadata and redemption preview tuple normalization for markets and partner pages
- keep Treasury settlement previews on Treasury where it remains the source of truth

Verification
- yarn web:check-types
- yarn workspace web lint --file app/markets/page.tsx --file app/partner/page.tsx --file components/markets/RedeemLiquidityModal.tsx --file utils/protocolState.ts
- git diff --check