### PR TITLE
test(evm): add manager unit coverage and invariants (ROB-86)

### DIFF
--- a/protocols/evm/test/property/PositionManagerAccounting.Invariant.t.sol
+++ b/protocols/evm/test/property/PositionManagerAccounting.Invariant.t.sol
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { Test } from "forge-std/Test.sol";
+import { TokenLib } from "../../contracts/Libraries.sol";
+import { PositionManager } from "../../contracts/PositionManager.sol";
+import { RoboshareTokens } from "../../contracts/RoboshareTokens.sol";
+
+contract PositionManagerAccountingHandler is Test {
+    RoboshareTokens internal roboshareTokens;
+    PositionManager internal positionManager;
+    address internal admin;
+    address internal managerActor;
+    address[] internal actors;
+    uint256 internal revenueTokenId;
+    uint256 internal tokenPrice;
+    uint256 internal maxSupply;
+
+    uint256 public expectedCurrentEpoch;
+    uint256 public expectedCurrentEpochSupply;
+    uint256 public expectedBackedPrincipal;
+    mapping(address => uint256) public expectedLocked;
+
+    constructor(
+        RoboshareTokens _roboshareTokens,
+        PositionManager _positionManager,
+        address _admin,
+        uint256 _revenueTokenId,
+        uint256 _tokenPrice,
+        uint256 _maxSupply,
+        address[] memory _actors
+    ) {
+        roboshareTokens = _roboshareTokens;
+        positionManager = _positionManager;
+        admin = _admin;
+        managerActor = address(_positionManager);
+        revenueTokenId = _revenueTokenId;
+        tokenPrice = _tokenPrice;
+        maxSupply = _maxSupply;
+        actors = _actors;
+    }
+
+    function mint(uint256 actorSeed, uint256 amountSeed) external {
+        uint256 currentSupply = roboshareTokens.getRevenueTokenSupply(revenueTokenId);
+        if (currentSupply >= maxSupply) return;
+
+        address holder = actors[actorSeed % actors.length];
+        uint256 amount = bound(amountSeed, 1, maxSupply - currentSupply);
+
+        vm.prank(admin);
+        roboshareTokens.mint(holder, revenueTokenId, amount, "");
+
+        expectedCurrentEpochSupply += amount;
+        expectedBackedPrincipal += amount * tokenPrice;
+    }
+
+    function transfer(uint256 fromSeed, uint256 toSeed, uint256 amountSeed) external {
+        address from = actors[fromSeed % actors.length];
+        address to = actors[toSeed % actors.length];
+        if (from == to) return;
+
+        uint256 balance = roboshareTokens.balanceOf(from, revenueTokenId);
+        uint256 locked = expectedLocked[from];
+        if (balance <= locked) return;
+
+        uint256 amount = bound(amountSeed, 1, balance - locked);
+
+        vm.prank(from);
+        roboshareTokens.safeTransferFrom(from, to, revenueTokenId, amount, "");
+    }
+
+    function burn(uint256 actorSeed, uint256 amountSeed) external {
+        address holder = actors[actorSeed % actors.length];
+        uint256 balance = roboshareTokens.balanceOf(holder, revenueTokenId);
+        uint256 locked = expectedLocked[holder];
+        if (balance <= locked) return;
+
+        uint256 amount = bound(amountSeed, 1, balance - locked);
+        uint256 burnedFromCurrentEpoch = _previewBurnedFromCurrentEpoch(holder, amount);
+
+        vm.prank(admin);
+        roboshareTokens.burn(holder, revenueTokenId, amount);
+
+        if (burnedFromCurrentEpoch > 0) {
+            expectedCurrentEpochSupply -= burnedFromCurrentEpoch;
+        }
+    }
+
+    function burnCurrentEpoch(uint256 actorSeed, uint256 amountSeed) external {
+        address holder = actors[actorSeed % actors.length];
+        uint256 eligibleBalance = roboshareTokens.getPrimaryRedemptionEligibleBalance(holder, revenueTokenId);
+        uint256 balance = roboshareTokens.balanceOf(holder, revenueTokenId);
+        uint256 locked = expectedLocked[holder];
+        if (eligibleBalance == 0 || balance <= locked) return;
+
+        uint256 amount = bound(amountSeed, 1, eligibleBalance < balance - locked ? eligibleBalance : balance - locked);
+
+        vm.prank(managerActor);
+        roboshareTokens.managerBurnCurrentEpoch(holder, revenueTokenId, amount);
+
+        expectedCurrentEpochSupply -= amount;
+    }
+
+    function lock(uint256 actorSeed, uint256 amountSeed) external {
+        address holder = actors[actorSeed % actors.length];
+        uint256 balance = roboshareTokens.balanceOf(holder, revenueTokenId);
+        uint256 locked = expectedLocked[holder];
+        if (balance <= locked) return;
+
+        uint256 amount = bound(amountSeed, 1, balance - locked);
+
+        vm.prank(managerActor);
+        roboshareTokens.lockForListing(holder, revenueTokenId, amount);
+
+        expectedLocked[holder] += amount;
+    }
+
+    function unlock(uint256 actorSeed, uint256 amountSeed) external {
+        address holder = actors[actorSeed % actors.length];
+        uint256 locked = expectedLocked[holder];
+        if (locked == 0) return;
+
+        uint256 amount = bound(amountSeed, 1, locked);
+
+        vm.prank(managerActor);
+        roboshareTokens.unlockForListing(holder, revenueTokenId, amount);
+
+        expectedLocked[holder] -= amount;
+    }
+
+    function transferLocked(uint256 fromSeed, uint256 toSeed, uint256 amountSeed) external {
+        address from = actors[fromSeed % actors.length];
+        address to = actors[toSeed % actors.length];
+        if (from == to) return;
+
+        uint256 locked = expectedLocked[from];
+        if (locked == 0) return;
+
+        uint256 amount = bound(amountSeed, 1, locked);
+
+        vm.prank(managerActor);
+        roboshareTokens.transferLockedForListing(from, to, revenueTokenId, amount, "");
+
+        expectedLocked[from] -= amount;
+    }
+
+    function releaseImmediate(uint256 amountSeed) external {
+        if (expectedBackedPrincipal == 0) return;
+
+        uint256 amount = bound(amountSeed, 1, expectedBackedPrincipal);
+
+        vm.prank(managerActor);
+        roboshareTokens.recordImmediateProceedsRelease(revenueTokenId, amount);
+
+        _applyPrincipalRelease(amount);
+    }
+
+    function payoutPrimary(uint256 amountSeed) external {
+        if (expectedBackedPrincipal == 0) return;
+
+        uint256 amount = bound(amountSeed, 1, expectedBackedPrincipal);
+
+        vm.prank(managerActor);
+        roboshareTokens.recordPrimaryRedemptionPayout(revenueTokenId, amount);
+
+        _applyPrincipalRelease(amount);
+    }
+
+    function actorCount() external view returns (uint256) {
+        return actors.length;
+    }
+
+    function actorAt(uint256 index) external view returns (address) {
+        return actors[index];
+    }
+
+    function _applyPrincipalRelease(uint256 amount) internal {
+        if (amount >= expectedBackedPrincipal) {
+            expectedBackedPrincipal = 0;
+        } else {
+            expectedBackedPrincipal -= amount;
+        }
+
+        _rollEpochIfExhausted();
+    }
+
+    function _rollEpochIfExhausted() internal {
+        if (expectedCurrentEpochSupply > 0 && expectedBackedPrincipal > 0) {
+            return;
+        }
+
+        expectedCurrentEpoch++;
+        expectedCurrentEpochSupply = 0;
+        expectedBackedPrincipal = 0;
+    }
+
+    function _previewBurnedFromCurrentEpoch(address holder, uint256 amount) internal view returns (uint256 burned) {
+        TokenLib.TokenPosition[] memory positions = roboshareTokens.getUserPositions(revenueTokenId, holder);
+        uint256 remaining = amount;
+        uint256 currentEpoch = positionManager.getCurrentPrimaryRedemptionEpoch(revenueTokenId);
+
+        for (uint256 i = 0; i < positions.length && remaining > 0; i++) {
+            if (positions[i].amount == 0) continue;
+
+            uint256 toBurn = remaining > positions[i].amount ? positions[i].amount : remaining;
+            if (positions[i].redemptionEpoch == currentEpoch) {
+                burned += toBurn;
+            }
+            remaining -= toBurn;
+        }
+    }
+}
+
+contract PositionManagerAccountingInvariantTest is StdInvariant, Test {
+    PositionManagerAccountingHandler internal handler;
+    RoboshareTokens internal roboshareTokens;
+    PositionManager internal positionManager;
+
+    address internal admin = makeAddr("admin");
+    address internal registryRouter = makeAddr("registryRouter");
+    address internal partnerManager = makeAddr("partnerManager");
+    address internal marketplace = makeAddr("marketplace");
+    address internal treasury = makeAddr("treasury");
+    address internal usdc = makeAddr("usdc");
+
+    uint256 internal constant REVENUE_TOKEN_ID = 102;
+    uint256 internal constant TOKEN_PRICE = 10e6;
+    uint256 internal constant MAX_SUPPLY = 500;
+
+    function setUp() public {
+        roboshareTokens = RoboshareTokens(
+            address(
+                new ERC1967Proxy(address(new RoboshareTokens()), abi.encodeCall(RoboshareTokens.initialize, (admin)))
+            )
+        );
+        positionManager = PositionManager(
+            address(
+                new ERC1967Proxy(
+                    address(new PositionManager()),
+                    abi.encodeCall(
+                        PositionManager.initialize,
+                        (admin, registryRouter, address(roboshareTokens), partnerManager, marketplace, treasury, usdc)
+                    )
+                )
+            )
+        );
+
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(positionManager));
+
+        vm.prank(admin);
+        roboshareTokens.setRevenueTokenInfo(
+            REVENUE_TOKEN_ID,
+            TOKEN_PRICE,
+            MAX_SUPPLY,
+            MAX_SUPPLY,
+            block.timestamp + 365 days,
+            10_000,
+            1_000,
+            false,
+            false
+        );
+
+        address[] memory actors = new address[](4);
+        actors[0] = makeAddr("alice");
+        actors[1] = makeAddr("bob");
+        actors[2] = makeAddr("carol");
+        actors[3] = makeAddr("dave");
+
+        for (uint256 i = 0; i < actors.length; i++) {
+            vm.etch(actors[i], bytes(""));
+        }
+
+        handler = new PositionManagerAccountingHandler(
+            roboshareTokens, positionManager, admin, REVENUE_TOKEN_ID, TOKEN_PRICE, MAX_SUPPLY, actors
+        );
+        targetContract(address(handler));
+    }
+
+    function invariantLockedAmountsMatchAccountingAndBalances() public view {
+        uint256 actorCount = handler.actorCount();
+        for (uint256 i = 0; i < actorCount; i++) {
+            address actor = handler.actorAt(i);
+            uint256 locked = positionManager.getLockedAmount(actor, REVENUE_TOKEN_ID);
+            assertEq(locked, handler.expectedLocked(actor), "locked amount drifted");
+            assertLe(locked, roboshareTokens.balanceOf(actor, REVENUE_TOKEN_ID), "locked exceeds balance");
+        }
+    }
+
+    function invariantCurrentEpochSupplyMatchesEligibleBalances() public view {
+        uint256 eligibleSum;
+        uint256 actorCount = handler.actorCount();
+
+        for (uint256 i = 0; i < actorCount; i++) {
+            eligibleSum += positionManager.getPrimaryRedemptionEligibleBalance(handler.actorAt(i), REVENUE_TOKEN_ID);
+        }
+
+        assertEq(
+            positionManager.getCurrentPrimaryRedemptionEpoch(REVENUE_TOKEN_ID),
+            handler.expectedCurrentEpoch(),
+            "current epoch drifted"
+        );
+        assertEq(
+            positionManager.getCurrentPrimaryRedemptionEpochSupply(REVENUE_TOKEN_ID),
+            handler.expectedCurrentEpochSupply(),
+            "current epoch supply drifted"
+        );
+        assertEq(
+            positionManager.getCurrentPrimaryRedemptionEpochSupply(REVENUE_TOKEN_ID),
+            eligibleSum,
+            "eligible balances do not match epoch supply"
+        );
+    }
+
+    function invariantBackedPrincipalMatchesAccounting() public view {
+        uint256 backedPrincipal = positionManager.getCurrentPrimaryRedemptionBackedPrincipal(REVENUE_TOKEN_ID);
+        assertEq(backedPrincipal, handler.expectedBackedPrincipal(), "backed principal drifted");
+    }
+}

--- a/protocols/evm/test/unit/PositionManager.t.sol
+++ b/protocols/evm/test/unit/PositionManager.t.sol
@@ -240,6 +240,84 @@ contract PositionManagerTest is Test {
         assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 100);
     }
 
+    function testBeforeRevenueTokenUpdateMintStoresPosition() public {
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(address(0), alice, TOKEN_ID, 80);
+
+        TokenLib.TokenPosition[] memory positions = positionManager.getUserPositions(TOKEN_ID, alice);
+        assertEq(positions.length, 1);
+        assertEq(positions[0].uid, 0);
+        assertEq(positions[0].tokenId, TOKEN_ID);
+        assertEq(positions[0].amount, 80);
+        assertGt(positions[0].acquiredAt, 0);
+        assertEq(positions[0].soldAt, 0);
+        assertEq(positions[0].redemptionEpoch, 0);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpoch(TOKEN_ID), 0);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 80);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 80 * TOKEN_PRICE);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 80);
+    }
+
+    function testBeforeRevenueTokenUpdateTransferMovesFifoLotsAndBurnConsumesRecipientQueue() public {
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(address(0), alice, TOKEN_ID, 100);
+        vm.warp(block.timestamp + 1);
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(address(0), alice, TOKEN_ID, 50);
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(alice, bob, TOKEN_ID, 120);
+
+        TokenLib.TokenPosition[] memory alicePositions = positionManager.getUserPositions(TOKEN_ID, alice);
+        assertEq(alicePositions.length, 2);
+        assertEq(alicePositions[0].amount, 0);
+        assertEq(alicePositions[1].amount, 30);
+
+        TokenLib.TokenPosition[] memory bobPositions = positionManager.getUserPositions(TOKEN_ID, bob);
+        assertEq(bobPositions.length, 2);
+        assertEq(bobPositions[0].amount, 100);
+        assertEq(bobPositions[0].redemptionEpoch, 0);
+        assertEq(bobPositions[1].amount, 20);
+        assertEq(bobPositions[1].redemptionEpoch, 0);
+        assertLt(bobPositions[0].acquiredAt, bobPositions[1].acquiredAt);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 150);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 150 * TOKEN_PRICE);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 30);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(bob, TOKEN_ID), 120);
+
+        vm.warp(block.timestamp + 1);
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(bob, address(0), TOKEN_ID, 110);
+
+        bobPositions = positionManager.getUserPositions(TOKEN_ID, bob);
+        assertEq(bobPositions.length, 2);
+        assertEq(bobPositions[0].amount, 0);
+        assertTrue(bobPositions[0].soldAt > 0);
+        assertEq(bobPositions[1].amount, 10);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 40);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 150 * TOKEN_PRICE);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(alice, TOKEN_ID), 30);
+        assertEq(positionManager.getPrimaryRedemptionEligibleBalance(bob, TOKEN_ID), 10);
+    }
+
+    function testBeforeRevenueTokenUpdateTransferRevertsWhenSenderBalanceIsInsufficient() public {
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(address(0), alice, TOKEN_ID, 50);
+
+        vm.expectRevert(TokenLib.InsufficientTokenBalance.selector);
+        vm.prank(roboshareTokens);
+        positionManager.beforeRevenueTokenUpdate(alice, bob, TOKEN_ID, 51);
+
+        TokenLib.TokenPosition[] memory alicePositions = positionManager.getUserPositions(TOKEN_ID, alice);
+        TokenLib.TokenPosition[] memory bobPositions = positionManager.getUserPositions(TOKEN_ID, bob);
+        assertEq(alicePositions.length, 1);
+        assertEq(alicePositions[0].amount, 50);
+        assertEq(bobPositions.length, 0);
+        assertEq(positionManager.getCurrentPrimaryRedemptionEpochSupply(TOKEN_ID), 50);
+        assertEq(positionManager.getCurrentPrimaryRedemptionBackedPrincipal(TOKEN_ID), 50 * TOKEN_PRICE);
+    }
+
     function testBurnConsumesPositionsFifo() public {
         vm.startPrank(marketplace);
         positionManager.recordPositionMutation(

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -75,6 +75,26 @@ contract MockPositionManager {
     function recordPrimaryRedemptionPayout(uint256, uint256, bytes32) external { }
 }
 
+contract RevertingERC1155Receiver {
+    error ReceiveBlocked();
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+        revert ReceiveBlocked();
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        revert ReceiveBlocked();
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x4e2312e0 || interfaceId == 0x01ffc9a7;
+    }
+}
+
 contract RoboshareTokensTest is AssetMetadataBaseTest {
     address public minter;
     address public burner;
@@ -450,6 +470,49 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         assertEq(mockManager.lastAmount(), 25);
     }
 
+    function testRevenueTokenMintRevertsWhenPositionManagerHookReverts() public {
+        MockPositionManager mockManager = new MockPositionManager();
+
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(mockManager));
+
+        uint256 tokenId = 106;
+        uint256 amount = 100;
+        uint256 maturityDate = block.timestamp + 365 days;
+
+        vm.prank(minter);
+        roboshareTokens.setRevenueTokenInfo(
+            tokenId, 100 * 1e6, amount, amount, maturityDate, 10_000, 1_000, false, false
+        );
+
+        mockManager.setShouldRevert(true);
+
+        vm.expectRevert(MockPositionManager.HookBlocked.selector);
+        vm.prank(minter);
+        roboshareTokens.mint(user1, tokenId, amount, "");
+
+        assertEq(roboshareTokens.balanceOf(user1, tokenId), 0);
+        assertEq(mockManager.callCount(), 0);
+    }
+
+    function testRevenueTokenTransferRevertsWhenPositionManagerHookReverts() public {
+        MockPositionManager mockManager = new MockPositionManager();
+
+        vm.prank(admin);
+        roboshareTokens.setPositionManager(address(mockManager));
+
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+        mockManager.setShouldRevert(true);
+
+        vm.expectRevert(MockPositionManager.HookBlocked.selector);
+        vm.prank(user1);
+        roboshareTokens.safeTransferFrom(user1, user2, tokenId, 25, "");
+
+        assertEq(roboshareTokens.balanceOf(user1, tokenId), 100);
+        assertEq(roboshareTokens.balanceOf(user2, tokenId), 0);
+        assertEq(mockManager.callCount(), 1);
+    }
+
     function testRevenueTokenBurnRevertsWhenPositionManagerHookReverts() public {
         MockPositionManager mockManager = new MockPositionManager();
 
@@ -734,6 +797,22 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         assertEq(roboshareTokens.getLockedAmount(user1, tokenId), 25);
         assertEq(roboshareTokens.balanceOf(user1, tokenId), 85);
         assertEq(roboshareTokens.balanceOf(user2, tokenId), 15);
+    }
+
+    function testTransferLockedForListingRollsBackUnlockWhenReceiverRejects() public {
+        RevertingERC1155Receiver receiver = new RevertingERC1155Receiver();
+        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
+
+        vm.prank(manager);
+        roboshareTokens.lockForListing(user1, tokenId, 40);
+
+        vm.expectRevert();
+        vm.prank(manager);
+        roboshareTokens.transferLockedForListing(user1, address(receiver), tokenId, 15, "");
+
+        assertEq(roboshareTokens.getLockedAmount(user1, tokenId), 40);
+        assertEq(roboshareTokens.balanceOf(user1, tokenId), 100);
+        assertEq(roboshareTokens.balanceOf(address(receiver), tokenId), 0);
     }
 
     function testBurnCurrentEpochForPrimaryRedemptionNotRevenueToken() public {


### PR DESCRIPTION
Summary
- add FIFO manager-hook unit coverage for mint, transfer, burn, and insufficient-balance rollback
- add token-hook rollback coverage around mint, transfer, and locked-transfer delivery failures
- add focused local invariants for locked amounts, current-epoch supply, and backed-principal accounting

Verification
- forge test --offline --match-path test/unit/PositionManager.t.sol
- forge test --offline --match-path test/unit/RoboshareTokens.t.sol
- forge test --offline --match-path test/property/PositionManagerAccounting.Invariant.t.sol
- git diff --check