### PR TITLE
test(evm): refresh integration suites for manager model (ROB-87)

### DIFF
--- a/protocols/evm/test/base/MarketplaceFlowBaseTest.t.sol
+++ b/protocols/evm/test/base/MarketplaceFlowBaseTest.t.sol
@@ -13,7 +13,6 @@ abstract contract MarketplaceFlowBaseTest is TreasuryFlowBaseTest {
         uint256 marketplaceContractUsdc;
         uint256 partnerTokens;
         uint256 buyerTokens;
-        uint256 marketplaceTokens;
         uint256 timestamp;
     }
 
@@ -91,7 +90,6 @@ abstract contract MarketplaceFlowBaseTest is TreasuryFlowBaseTest {
         snapshot.marketplaceContractUsdc = usdc.balanceOf(address(marketplace));
         snapshot.partnerTokens = roboshareTokens.balanceOf(partner1, tokenId);
         snapshot.buyerTokens = roboshareTokens.balanceOf(buyer, tokenId);
-        snapshot.marketplaceTokens = roboshareTokens.balanceOf(address(marketplace), tokenId);
         snapshot.timestamp = block.timestamp;
     }
 

--- a/protocols/evm/test/base/TreasuryFlowBaseTest.t.sol
+++ b/protocols/evm/test/base/TreasuryFlowBaseTest.t.sol
@@ -171,4 +171,17 @@ abstract contract TreasuryFlowBaseTest is AssetMetadataBaseTest {
         protocolBuffer = (expectedQuarterlyEarnings * ProtocolLib.PROTOCOL_FEE_BP) / ProtocolLib.BP_PRECISION;
         total = earningsBuffer + protocolBuffer;
     }
+
+    function _grantBurnerRoleToSelf() internal {
+        vm.startPrank(admin);
+        roboshareTokens.grantRole(roboshareTokens.BURNER_ROLE(), address(this));
+        vm.stopPrank();
+    }
+
+    function _burnRevenueTokenBalance(uint256 revenueTokenId, address holder) internal {
+        uint256 balance = roboshareTokens.balanceOf(holder, revenueTokenId);
+        if (balance > 0) {
+            roboshareTokens.burn(holder, revenueTokenId, balance);
+        }
+    }
 }

--- a/protocols/evm/test/integration/EarningsManager.Integration.t.sol
+++ b/protocols/evm/test/integration/EarningsManager.Integration.t.sol
@@ -208,8 +208,13 @@ contract EarningsManagerIntegrationTest is MarketplaceFlowBaseTest {
         vm.prank(partner1);
         assetRegistry.settleAsset(scenario.assetId, 0);
 
+        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
         vm.prank(buyer);
         assetRegistry.claimSettlement(scenario.assetId, false);
+        assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), 0);
+        IPositionManager.SettlementClaimState memory claimState =
+            roboshareTokens.positionManager().getSettlementClaimState(scenario.assetId, buyer);
+        assertEq(claimState.burnedAmount, buyerBalance);
 
         uint256 previewAmount = earningsManager.previewClaimEarnings(scenario.assetId, buyer);
         assertGt(previewAmount, 0);
@@ -409,6 +414,7 @@ contract EarningsManagerIntegrationTest is MarketplaceFlowBaseTest {
         assertGt(settlementClaimed, 0);
         assertEq(earningsClaimed, 0);
         assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), 0);
+        assertGt(earningsManager.previewClaimEarnings(scenario.assetId, buyer), 0);
 
         vm.prank(buyer);
         earningsManager.claimEarnings(scenario.assetId);

--- a/protocols/evm/test/integration/Marketplace.Integration.t.sol
+++ b/protocols/evm/test/integration/Marketplace.Integration.t.sol
@@ -161,6 +161,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
         assertEq(lockedBefore, 0);
         assertEq(lockedAfter, buyerBalance);
         assertEq(buyerBalanceAfter, buyerBalanceBefore);
+        assertEq(roboshareTokens.balanceOf(address(marketplace), scenario.revenueTokenId), 0);
         Marketplace.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.amount, buyerBalance);
     }
@@ -602,6 +603,7 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
         assertGe(eligibleBalance, burnAmount);
         assertEq(redemptionSupply, manager.getCurrentPrimaryRedemptionEpochSupply(scenario.revenueTokenId));
         assertEq(eligibleBalance, manager.getPrimaryRedemptionEligibleBalance(buyer, scenario.revenueTokenId));
+        uint256 backedPrincipalBefore = manager.getCurrentPrimaryRedemptionBackedPrincipal(scenario.revenueTokenId);
 
         uint256 buyerUsdcBefore = usdc.balanceOf(buyer);
         uint256 buyerTokensBefore = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
@@ -612,6 +614,10 @@ contract MarketplaceIntegrationTest is MarketplaceFlowBaseTest {
 
         assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), buyerTokensBefore - burnAmount);
         assertEq(usdc.balanceOf(buyer), buyerUsdcBefore + payout);
+        assertEq(manager.getCurrentPrimaryRedemptionEpochSupply(scenario.revenueTokenId), redemptionSupply - burnAmount);
+        assertEq(
+            manager.getCurrentPrimaryRedemptionBackedPrincipal(scenario.revenueTokenId), backedPrincipalBefore - payout
+        );
     }
 
     function testPreviewPrimaryRedemptionZeroAmount() public {

--- a/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
+++ b/protocols/evm/test/integration/RegistryRouter.Integration.t.sol
@@ -526,9 +526,9 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
         vm.prank(partner1);
         assetRegistry.settleAsset(scenario.assetId, 0);
 
+        IPositionManager positionManager = roboshareTokens.positionManager();
         uint256 buyerBalance = roboshareTokens.balanceOf(buyer, scenario.revenueTokenId);
-        uint256 expectedPayout =
-            roboshareTokens.positionManager().previewSettlementClaim(scenario.assetId, buyerBalance);
+        uint256 expectedPayout = positionManager.previewSettlementClaim(scenario.assetId, buyerBalance);
 
         vm.prank(buyer);
         (uint256 claimedAmount, uint256 earningsClaimed) = router.claimSettlement(scenario.assetId, false);
@@ -536,6 +536,10 @@ contract RegistryRouterIntegrationTest is TreasuryFlowBaseTest {
         assertEq(earningsClaimed, 0);
         assertEq(claimedAmount, expectedPayout);
         assertEq(roboshareTokens.balanceOf(buyer, scenario.revenueTokenId), 0);
+        IPositionManager.SettlementClaimState memory claimState =
+            positionManager.getSettlementClaimState(scenario.assetId, buyer);
+        assertEq(claimState.burnedAmount, buyerBalance);
+        assertEq(claimState.payout, claimedAmount);
     }
 
     // TreasuryNotSet Tests

--- a/protocols/evm/test/integration/Treasury.Integration.t.sol
+++ b/protocols/evm/test/integration/Treasury.Integration.t.sol
@@ -680,26 +680,10 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     function testReleaseCollateral() public {
         _ensureState(SetupState.BuffersFunded);
 
-        // Burn tokens first (prerequisite for full release)
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(scenario.assetId);
-
-        // Grant burner role to this test contract to simulate burning
-        vm.startPrank(admin);
-        roboshareTokens.grantRole(roboshareTokens.BURNER_ROLE(), address(this));
-        vm.stopPrank();
-
-        uint256 marketplaceBalance = roboshareTokens.balanceOf(address(marketplace), revenueTokenId);
-        if (marketplaceBalance > 0) {
-            roboshareTokens.burn(address(marketplace), revenueTokenId, marketplaceBalance);
-        }
-        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, revenueTokenId);
-        if (buyerBalance > 0) {
-            roboshareTokens.burn(buyer, revenueTokenId, buyerBalance);
-        }
-        uint256 partnerBalance = roboshareTokens.balanceOf(partner1, revenueTokenId);
-        if (partnerBalance > 0) {
-            roboshareTokens.burn(partner1, revenueTokenId, partnerBalance);
-        }
+        _grantBurnerRoleToSelf();
+        _burnRevenueTokenBalance(revenueTokenId, buyer);
+        _burnRevenueTokenBalance(revenueTokenId, partner1);
 
         // Partner calls releaseCollateral
         uint256 pendingBefore = treasury.pendingWithdrawals(partner1);
@@ -714,25 +698,10 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     function testReleaseCollateralFor() public {
         _ensureState(SetupState.BuffersFunded);
 
-        // Burn tokens first
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(scenario.assetId);
-
-        vm.startPrank(admin);
-        roboshareTokens.grantRole(roboshareTokens.BURNER_ROLE(), address(this));
-        vm.stopPrank();
-
-        uint256 marketplaceBalance = roboshareTokens.balanceOf(address(marketplace), revenueTokenId);
-        if (marketplaceBalance > 0) {
-            roboshareTokens.burn(address(marketplace), revenueTokenId, marketplaceBalance);
-        }
-        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, revenueTokenId);
-        if (buyerBalance > 0) {
-            roboshareTokens.burn(buyer, revenueTokenId, buyerBalance);
-        }
-        uint256 partnerBalance = roboshareTokens.balanceOf(partner1, revenueTokenId);
-        if (partnerBalance > 0) {
-            roboshareTokens.burn(partner1, revenueTokenId, partnerBalance);
-        }
+        _grantBurnerRoleToSelf();
+        _burnRevenueTokenBalance(revenueTokenId, buyer);
+        _burnRevenueTokenBalance(revenueTokenId, partner1);
 
         uint256 pendingBefore = treasury.pendingWithdrawals(partner1);
         vm.prank(address(router));
@@ -820,25 +789,10 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
     function testProcessWithdrawal() public {
         _ensureState(SetupState.BuffersFunded);
 
-        // Burn tokens first
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(scenario.assetId);
-
-        vm.startPrank(admin);
-        roboshareTokens.grantRole(roboshareTokens.BURNER_ROLE(), address(this));
-        vm.stopPrank();
-
-        uint256 marketplaceBalance = roboshareTokens.balanceOf(address(marketplace), revenueTokenId);
-        if (marketplaceBalance > 0) {
-            roboshareTokens.burn(address(marketplace), revenueTokenId, marketplaceBalance);
-        }
-        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, revenueTokenId);
-        if (buyerBalance > 0) {
-            roboshareTokens.burn(buyer, revenueTokenId, buyerBalance);
-        }
-        uint256 partnerBalance = roboshareTokens.balanceOf(partner1, revenueTokenId);
-        if (partnerBalance > 0) {
-            roboshareTokens.burn(partner1, revenueTokenId, partnerBalance);
-        }
+        _grantBurnerRoleToSelf();
+        _burnRevenueTokenBalance(revenueTokenId, buyer);
+        _burnRevenueTokenBalance(revenueTokenId, partner1);
 
         vm.prank(address(router));
         treasury.releaseCollateralFor(partner1, scenario.assetId);
@@ -930,25 +884,10 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         // 1. Lock Collateral (already done in setup)
         assertTrue(_getCollateralInfo(scenario.assetId).isLocked);
 
-        // 2. Burn tokens
         uint256 revenueTokenId = TokenLib.getTokenIdFromAssetId(scenario.assetId);
-
-        vm.startPrank(admin);
-        roboshareTokens.grantRole(roboshareTokens.BURNER_ROLE(), address(this));
-        vm.stopPrank();
-
-        uint256 marketplaceBalance = roboshareTokens.balanceOf(address(marketplace), revenueTokenId);
-        if (marketplaceBalance > 0) {
-            roboshareTokens.burn(address(marketplace), revenueTokenId, marketplaceBalance);
-        }
-        uint256 buyerBalance = roboshareTokens.balanceOf(buyer, revenueTokenId);
-        if (buyerBalance > 0) {
-            roboshareTokens.burn(buyer, revenueTokenId, buyerBalance);
-        }
-        uint256 partnerBalance = roboshareTokens.balanceOf(partner1, revenueTokenId);
-        if (partnerBalance > 0) {
-            roboshareTokens.burn(partner1, revenueTokenId, partnerBalance);
-        }
+        _grantBurnerRoleToSelf();
+        _burnRevenueTokenBalance(revenueTokenId, buyer);
+        _burnRevenueTokenBalance(revenueTokenId, partner1);
 
         // 3. Unlock Collateral
         vm.prank(address(router));
@@ -1006,6 +945,9 @@ contract TreasuryIntegrationTest is MarketplaceFlowBaseTest, ERC1155Holder {
         (uint256 settlementClaimed,) = assetRegistry.claimSettlement(scenario.assetId, false);
 
         assertEq(settlementClaimed, previewAmount, "Preview should match settlement claimed");
+        settlementState = positionManager.getSettlementState(scenario.assetId);
+        assertEq(settlementState.claimedBurnAmount, buyerBalance, "Settlement aggregate should track burned amount");
+        assertEq(settlementState.claimedPayout, settlementClaimed, "Settlement aggregate should track claimed payout");
         IPositionManager.SettlementClaimState memory claimState =
             positionManager.getSettlementClaimState(scenario.assetId, buyer);
         assertEq(claimState.burnedAmount, buyerBalance, "PositionManager should track claimed burn amount");

--- a/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
+++ b/protocols/evm/test/integration/VehicleRegistry.Integration.t.sol
@@ -587,9 +587,10 @@ contract VehicleRegistryIntegrationTest is VehicleRegistryBaseTest, MarketplaceF
         _ensureState(SetupState.PrimaryPoolCreated);
         uint256 totalSupply = roboshareTokens.getRevenueTokenSupply(scenario.revenueTokenId);
 
-        // In the continuous primary-pool model, no buys means no outstanding revenue token supply.
+        // In the manager-backed primary-pool model, inventory is capacity only until a buy mints positions.
+        assertEq(totalSupply, 0);
         assertEq(roboshareTokens.balanceOf(partner1, scenario.revenueTokenId), 0);
-        assertEq(roboshareTokens.balanceOf(address(marketplace), scenario.revenueTokenId), totalSupply);
+        assertEq(roboshareTokens.balanceOf(address(marketplace), scenario.revenueTokenId), 0);
 
         CollateralLib.CollateralInfo memory info = _getCollateralInfo(scenario.assetId);
         uint256 expectedCollateral = _getCollateralTotal(info);


### PR DESCRIPTION
Summary
- refresh manager-model assertions across listing, redemption, earnings, settlement, and retirement flows
- remove stale marketplace-custody assumptions from shared flow helpers
- centralize the test-only burn setup used by treasury collateral-release flows

Verification
- forge test --offline --match-path test/integration/Marketplace.Integration.t.sol
- forge test --offline --match-path test/integration/Treasury.Integration.t.sol
- forge test --offline --match-path test/integration/RegistryRouter.Integration.t.sol
- forge test --offline --match-path test/integration/EarningsManager.Integration.t.sol
- forge test --offline --match-path test/integration/VehicleRegistry.Integration.t.sol
- git diff --check