### PR TITLE
refactor(evm): drop token manager compatibility aliases (ROB-98)

### DIFF
--- a/protocols/evm/contracts/RoboshareTokens.sol
+++ b/protocols/evm/contracts/RoboshareTokens.sol
@@ -200,23 +200,6 @@ contract RoboshareTokens is
         _burnBatch(from, ids, amounts);
     }
 
-    function managerTransfer(address from, address to, uint256 id, uint256 amount, bytes memory data)
-        external
-        onlyRole(MANAGER_ROLE)
-    {
-        if (!TokenLib.isRevenueToken(id)) {
-            revert NotRevenueToken();
-        }
-        _safeTransferFrom(from, to, id, amount, data);
-    }
-
-    function managerBurn(address from, uint256 id, uint256 amount) external onlyRole(MANAGER_ROLE) {
-        if (!TokenLib.isRevenueToken(id)) {
-            revert NotRevenueToken();
-        }
-        _burn(from, id, amount);
-    }
-
     function managerBurnCurrentEpoch(address holder, uint256 revenueTokenId, uint256 amount)
         external
         onlyRole(MANAGER_ROLE)
@@ -395,16 +378,6 @@ contract RoboshareTokens is
         _requirePositionManager().unlockForListing(holder, revenueTokenId, amount);
     }
 
-    /**
-     * @dev Deprecated compatibility alias for managerBurnCurrentEpoch().
-     */
-    function burnCurrentEpochForPrimaryRedemption(address holder, uint256 revenueTokenId, uint256 amount)
-        external
-        onlyRole(MANAGER_ROLE)
-    {
-        _managerBurnCurrentEpoch(holder, revenueTokenId, amount);
-    }
-
     function _managerBurnCurrentEpoch(address holder, uint256 revenueTokenId, uint256 amount) internal {
         if (!TokenLib.isRevenueToken(revenueTokenId)) {
             revert NotRevenueToken();
@@ -412,30 +385,6 @@ contract RoboshareTokens is
         if (amount == 0) revert InvalidLockAmount();
         _requirePositionManager().preparePrimaryRedemptionBurn(holder, revenueTokenId);
         _burn(holder, revenueTokenId, amount);
-    }
-
-    function recordImmediateProceedsRelease(uint256 revenueTokenId, uint256 releasedAmount)
-        external
-        onlyRole(MANAGER_ROLE)
-    {
-        if (!TokenLib.isRevenueToken(revenueTokenId)) {
-            revert NotRevenueToken();
-        }
-        if (releasedAmount == 0) return;
-        _requirePositionManager()
-            .recordImmediateProceedsRelease(revenueTokenId, releasedAmount, keccak256("IMMEDIATE_PROCEEDS_RELEASE"));
-    }
-
-    function recordPrimaryRedemptionPayout(uint256 revenueTokenId, uint256 payoutAmount)
-        external
-        onlyRole(MANAGER_ROLE)
-    {
-        if (!TokenLib.isRevenueToken(revenueTokenId)) {
-            revert NotRevenueToken();
-        }
-        if (payoutAmount == 0) return;
-        _requirePositionManager()
-            .recordPrimaryRedemptionPayout(revenueTokenId, payoutAmount, keccak256("PRIMARY_REDEMPTION_PAYOUT"));
     }
 
     function transferLockedForListing(

--- a/protocols/evm/test/property/PositionManagerAccounting.Invariant.t.sol
+++ b/protocols/evm/test/property/PositionManagerAccounting.Invariant.t.sol
@@ -13,6 +13,7 @@ contract PositionManagerAccountingHandler is Test {
     PositionManager internal positionManager;
     address internal admin;
     address internal managerActor;
+    address internal proceedsActor;
     address[] internal actors;
     uint256 internal revenueTokenId;
     uint256 internal tokenPrice;
@@ -27,6 +28,7 @@ contract PositionManagerAccountingHandler is Test {
         RoboshareTokens _roboshareTokens,
         PositionManager _positionManager,
         address _admin,
+        address _proceedsActor,
         uint256 _revenueTokenId,
         uint256 _tokenPrice,
         uint256 _maxSupply,
@@ -36,6 +38,7 @@ contract PositionManagerAccountingHandler is Test {
         positionManager = _positionManager;
         admin = _admin;
         managerActor = address(_positionManager);
+        proceedsActor = _proceedsActor;
         revenueTokenId = _revenueTokenId;
         tokenPrice = _tokenPrice;
         maxSupply = _maxSupply;
@@ -151,8 +154,8 @@ contract PositionManagerAccountingHandler is Test {
 
         uint256 amount = bound(amountSeed, 1, expectedBackedPrincipal);
 
-        vm.prank(managerActor);
-        roboshareTokens.recordImmediateProceedsRelease(revenueTokenId, amount);
+        vm.prank(proceedsActor);
+        positionManager.recordImmediateProceedsRelease(revenueTokenId, amount, keccak256("IMMEDIATE_PROCEEDS_RELEASE"));
 
         _applyPrincipalRelease(amount);
     }
@@ -162,8 +165,8 @@ contract PositionManagerAccountingHandler is Test {
 
         uint256 amount = bound(amountSeed, 1, expectedBackedPrincipal);
 
-        vm.prank(managerActor);
-        roboshareTokens.recordPrimaryRedemptionPayout(revenueTokenId, amount);
+        vm.prank(proceedsActor);
+        positionManager.recordPrimaryRedemptionPayout(revenueTokenId, amount, keccak256("PRIMARY_REDEMPTION_PAYOUT"));
 
         _applyPrincipalRelease(amount);
     }
@@ -274,7 +277,7 @@ contract PositionManagerAccountingInvariantTest is StdInvariant, Test {
         }
 
         handler = new PositionManagerAccountingHandler(
-            roboshareTokens, positionManager, admin, REVENUE_TOKEN_ID, TOKEN_PRICE, MAX_SUPPLY, actors
+            roboshareTokens, positionManager, admin, registryRouter, REVENUE_TOKEN_ID, TOKEN_PRICE, MAX_SUPPLY, actors
         );
         targetContract(address(handler));
     }

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -374,69 +374,6 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.setURI("ipfs://new-uri");
     }
 
-    function testManagerTransferUnauthorizedCaller() public {
-        vm.prank(minter);
-        roboshareTokens.mint(user1, 101, 100, "");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, unauthorized, roboshareTokens.MANAGER_ROLE()
-            )
-        );
-        vm.prank(unauthorized);
-        roboshareTokens.managerTransfer(user1, user2, 101, 10, "");
-    }
-
-    function testManagerTransferMovesTokens() public {
-        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-
-        vm.prank(manager);
-        roboshareTokens.managerTransfer(user1, user2, tokenId, 10, "");
-
-        assertEq(roboshareTokens.balanceOf(user1, tokenId), 90);
-        assertEq(roboshareTokens.balanceOf(user2, tokenId), 10);
-    }
-
-    function testManagerBurnUnauthorizedCaller() public {
-        vm.prank(minter);
-        roboshareTokens.mint(user1, 101, 100, "");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, unauthorized, roboshareTokens.MANAGER_ROLE()
-            )
-        );
-        vm.prank(unauthorized);
-        roboshareTokens.managerBurn(user1, 101, 10);
-    }
-
-    function testManagerBurnBurnsTokens() public {
-        uint256 tokenId = _setupRevenueTokenForLocks(user1, 100);
-
-        vm.prank(manager);
-        roboshareTokens.managerBurn(user1, tokenId, 10);
-
-        assertEq(roboshareTokens.balanceOf(user1, tokenId), 90);
-    }
-
-    function testManagerTransferNotRevenueToken() public {
-        vm.prank(minter);
-        roboshareTokens.mint(user1, 101, 100, "");
-
-        vm.prank(manager);
-        vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
-        roboshareTokens.managerTransfer(user1, user2, 101, 10, "");
-    }
-
-    function testManagerBurnNotRevenueToken() public {
-        vm.prank(minter);
-        roboshareTokens.mint(user1, 101, 100, "");
-
-        vm.prank(manager);
-        vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
-        roboshareTokens.managerBurn(user1, 101, 10);
-    }
-
     function testRevenueTokenMintCallsPositionManagerHook() public {
         MockPositionManager mockManager = new MockPositionManager();
 
@@ -815,18 +752,18 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         assertEq(roboshareTokens.balanceOf(address(receiver), tokenId), 0);
     }
 
-    function testBurnCurrentEpochForPrimaryRedemptionNotRevenueToken() public {
+    function testManagerBurnCurrentEpochNotRevenueToken() public {
         vm.prank(manager);
         vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
-        roboshareTokens.burnCurrentEpochForPrimaryRedemption(user1, 101, 1);
+        roboshareTokens.managerBurnCurrentEpoch(user1, 101, 1);
     }
 
-    function testBurnCurrentEpochForPrimaryRedemptionZeroAmount() public {
+    function testManagerBurnCurrentEpochZeroAmount() public {
         uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
 
         vm.prank(manager);
         vm.expectRevert(RoboshareTokens.InvalidLockAmount.selector);
-        roboshareTokens.burnCurrentEpochForPrimaryRedemption(user1, tokenId, 0);
+        roboshareTokens.managerBurnCurrentEpoch(user1, tokenId, 0);
     }
 
     function testManagerBurnCurrentEpochUnauthorizedCaller() public {
@@ -841,99 +778,18 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.managerBurnCurrentEpoch(user1, tokenId, 1);
     }
 
-    function testBurnCurrentEpochForPrimaryRedemptionRequiresEligibleEpochBalance() public {
+    function testManagerBurnCurrentEpochRequiresEligibleEpochBalance() public {
         uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
         uint256 backedPrincipal = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
 
-        vm.prank(manager);
-        roboshareTokens.recordImmediateProceedsRelease(tokenId, backedPrincipal);
+        vm.prank(address(router));
+        testPositionManager.recordImmediateProceedsRelease(
+            tokenId, backedPrincipal, keccak256("IMMEDIATE_PROCEEDS_RELEASE")
+        );
 
         vm.prank(manager);
         vm.expectRevert(TokenLib.InsufficientTokenBalance.selector);
-        roboshareTokens.burnCurrentEpochForPrimaryRedemption(user1, tokenId, 1);
-    }
-
-    function testRecordImmediateProceedsReleaseNotRevenueToken() public {
-        vm.prank(manager);
-        vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
-        roboshareTokens.recordImmediateProceedsRelease(101, 1);
-    }
-
-    function testRecordImmediateProceedsReleaseZeroAmountNoOp() public {
-        uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
-        uint256 epochBefore = roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId);
-        uint256 principalBefore = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
-
-        vm.prank(manager);
-        roboshareTokens.recordImmediateProceedsRelease(tokenId, 0);
-
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), epochBefore);
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId), principalBefore);
-    }
-
-    function testRecordImmediateProceedsReleaseNoBackedPrincipalNoOp() public {
-        uint256 tokenId = 106;
-        uint256 maturityDate = block.timestamp + 365 days;
-
-        vm.prank(minter);
-        roboshareTokens.setRevenueTokenInfo(tokenId, 100 * 1e6, 100, 100, maturityDate, 10_000, 1_000, true, false);
-
-        vm.prank(manager);
-        roboshareTokens.recordImmediateProceedsRelease(tokenId, 1);
-
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), 0);
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId), 0);
-    }
-
-    function testRecordPrimaryRedemptionPayoutNotRevenueToken() public {
-        vm.prank(manager);
-        vm.expectRevert(RoboshareTokens.NotRevenueToken.selector);
-        roboshareTokens.recordPrimaryRedemptionPayout(101, 1);
-    }
-
-    function testRecordPrimaryRedemptionPayoutZeroAmountNoOp() public {
-        uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
-        uint256 supplyBefore = roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId);
-        uint256 principalBefore = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
-
-        vm.prank(manager);
-        roboshareTokens.recordPrimaryRedemptionPayout(tokenId, 0);
-
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), supplyBefore);
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId), principalBefore);
-    }
-
-    function testRecordPrimaryRedemptionPayoutAdvancesEpochWhenExhausted() public {
-        uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
-        uint256 backedPrincipal = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
-
-        vm.prank(manager);
-        roboshareTokens.recordPrimaryRedemptionPayout(tokenId, backedPrincipal);
-
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), 0);
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId), 0);
-        assertEq(roboshareTokens.getPrimaryRedemptionEligibleBalance(user1, tokenId), 0);
-    }
-
-    function testRecordPrimaryRedemptionPayoutAdvancesEpochWhenSupplyExhaustedBeforePrincipal() public {
-        uint256 tokenId = _setupRevenueTokenForRedemptionEpochs(user1, 100);
-        uint256 principalBefore = roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId);
-
-        vm.prank(burner);
-        roboshareTokens.burn(user1, tokenId, 100);
-
-        vm.prank(manager);
-        roboshareTokens.recordPrimaryRedemptionPayout(tokenId, principalBefore / 2);
-
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionEpochSupply(tokenId), 0);
-        assertEq(roboshareTokens.getCurrentPrimaryRedemptionBackedPrincipal(tokenId), 0);
-        assertEq(roboshareTokens.getPrimaryRedemptionEligibleBalance(user1, tokenId), 0);
-
-        vm.prank(minter);
-        roboshareTokens.mint(user2, tokenId, 10, "");
-
-        assertEq(roboshareTokens.getPrimaryRedemptionEligibleBalance(user1, tokenId), 0);
-        assertEq(roboshareTokens.getPrimaryRedemptionEligibleBalance(user2, tokenId), 10);
+        roboshareTokens.managerBurnCurrentEpoch(user1, tokenId, 1);
     }
 
     function testBurnRevenueTokenSkipsConsumedHeadPositions() public {


### PR DESCRIPTION
Summary
- remove deprecated token-side manager compatibility aliases that are no longer part of the live manager-mediated flow
- retarget unit coverage to the surviving manager current-epoch burn path

Verification
- forge test --offline --match-path test/unit/RoboshareTokens.t.sol
- git diff --check