### PR TITLE
test(evm): add remaining unit coverage followups (ROB-99)

### DIFF
--- a/protocols/evm/test/unit/Libraries.t.sol
+++ b/protocols/evm/test/unit/Libraries.t.sol
@@ -84,6 +84,12 @@ contract VehicleHelper {
         return info.vinHash;
     }
 
+    function initWithHash(bytes32 vinHashValue, string memory assetMetadataURI, string memory revenueTokenMetadataURI)
+        external
+    {
+        info.initializeVehicleInfo(vinHashValue, assetMetadataURI, revenueTokenMetadataURI);
+    }
+
     function updateMeta(string memory uri) external {
         info.updateMetadata(uri, uri);
     }
@@ -684,6 +690,13 @@ contract LibrariesTest is Test {
     function testVehicleInvalidMetadataUri() public {
         vm.expectRevert(VehicleLib.InvalidMetadataURI.selector);
         vh.init("1HGCM82633A123456", "http://bad-uri", "ipfs://QmRevenueTokenMetadata");
+    }
+
+    function testVehicleInitializeRejectsZeroVinHash() public {
+        vm.expectRevert(VehicleLib.InvalidVINLength.selector);
+        vh.initWithHash(
+            bytes32(0), "ipfs://QmYwAPJzv5CZsnAzt8auVTLpG1bG6dkprdFM5ocTyBCQb", "ipfs://QmRevenueTokenMetadata"
+        );
     }
 
     function testTokenUnclaimedForPositionsAndEarningsHelpers() public {

--- a/protocols/evm/test/unit/RoboshareTokens.t.sol
+++ b/protocols/evm/test/unit/RoboshareTokens.t.sol
@@ -294,6 +294,12 @@ contract RoboshareTokensTest is AssetMetadataBaseTest {
         roboshareTokens.setTokenMetadataURI(1, "ipfs://QmTokenMetadata");
     }
 
+    function testSetTokenMetadataURIRejectsEmptyUri() public {
+        vm.expectRevert(RoboshareTokens.EmptyMetadataURI.selector);
+        vm.prank(admin);
+        roboshareTokens.setTokenMetadataURI(1, "");
+    }
+
     function testTransfers() public {
         // Setup: mint tokens to user1
         uint256 tokenId = 101;


### PR DESCRIPTION
Summary
- add focused unit coverage for the zero-vin-hash vehicle initialization guard
- add focused unit coverage for empty token metadata URI rejection

Verification
- forge test --offline --match-path test/unit/Libraries.t.sol --match-test testVehicleInitializeRejectsZeroVinHash
- forge test --offline --match-path test/unit/RoboshareTokens.t.sol --match-test testSetTokenMetadataURIRejectsEmptyUri
- git diff --check